### PR TITLE
Implemented comments by transforming them into an unused element.

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -58,6 +58,7 @@ impl Parser {
             match self.peek().kind {
                 TokenType::TagStart => self.parse_tag_block(),
                 TokenType::VariableStart => self.parse_variable_block(),
+                TokenType::Comment => { self.next_non_space(); },
                 TokenType::Text => self.parse_text(),
                 TokenType::Eof => break,
                 _ => unreachable!()

--- a/src/render.rs
+++ b/src/render.rs
@@ -429,7 +429,28 @@ mod tests {
         assert_eq!(result.unwrap(), "Vat: £20.".to_owned());
     }
 
-    #[test]
+	#[test]
+	fn test_render_comment() {
+		let result = Template::new("", "<h1>Hello {# comment #} world</h1>").render(Context::new(), HashMap::new());
+		assert_eq!(result.unwrap(), "<h1>Hello  world</h1>".to_owned());
+	}
+
+	#[test]
+	fn test_render_nested_comment() {
+		let result = Template::new("", "<h1>Hello {# comment {# nested #} world</h1>").render(Context::new(), HashMap::new());
+		assert_eq!(result.unwrap(), "<h1>Hello  world</h1>".to_owned());
+	}
+
+	#[test]
+	fn test_ignore_variable_in_comment() {
+		let mut context = Context::new();
+		context.add("name", &"Vincent");
+
+		let result = Template::new("", "My name {# was {{ name }} #} is No One.").render(context, HashMap::new());
+		assert_eq!(result.unwrap(), "My name  is No One.".to_owned());
+	}
+
+	#[test]
     fn test_render_if_simple() {
         let mut context = Context::new();
         context.add("is_admin", &true);


### PR DESCRIPTION
Hi,

as I said in the previous PR, this is the second version of the comments lexer-parser.
This one finds the starting {# and lexes until the next #} comment in a single tag that then gets ignored by the parser.
