### PR TITLE
fix dir bug on windows

### DIFF
--- a/src/tera.rs
+++ b/src/tera.rs
@@ -36,6 +36,7 @@ impl Tera {
         // We are parsing all the templates on instantiation
         for entry in glob(dir).unwrap().filter_map(|e| e.ok()) {
             let path = entry.as_path();
+            println!("{:?}", path);
             // We only care about actual files
             if path.is_file() {
                 // We clean the filename by removing the dir given
@@ -49,6 +50,8 @@ impl Tera {
                 templates.insert(filepath.to_owned(), Template::new(&filepath, &input));
             }
         }
+
+        println!("templates {:?}", templates);
 
         Tera {
             templates: templates

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -35,17 +35,14 @@ impl Tera {
         // We are parsing all the templates on instantiation
         for entry in glob(dir).unwrap().filter_map(|e| e.ok()) {
             let path = entry.as_path();
-            // println!("{:?}", path);
             // We only care about actual files
             if path.is_file() {
                 // We clean the filename by removing the dir given
                 // to Tera so users don't have to prefix everytime
                 let parent_dir = dir.split_at(dir.find('*').unwrap()).0;
-                // println!(" parent dir {:?}", parent_dir);
-                let filepath = path.to_string_lossy().replace("\\", "/");
-                // println!(" filepath {:?}", filepath);
-                let filepath = filepath.replace(parent_dir, "");
-                // println!(" filepath {:?}", filepath);
+                let filepath = path.to_string_lossy()
+                                 .replace("\\", "/")
+                                 .replace(parent_dir, "");
                 // we know the file exists so unwrap all the things
                 let mut f = File::open(path).unwrap();
                 let mut input = String::new();

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -42,7 +42,8 @@ impl Tera {
                 // We clean the filename by removing the dir given
                 // to Tera so users don't have to prefix everytime
                 let parent_dir = dir.split_at(dir.find('*').unwrap()).0;
-                let filepath = path.to_string_lossy().replace(parent_dir, "");
+                let filepath = path.to_string_lossy().replace(parent_dir, "")
+                                   .replace(r"\\", r"/");
                 // we know the file exists so unwrap all the things
                 let mut f = File::open(path).unwrap();
                 let mut input = String::new();

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -42,8 +42,7 @@ impl Tera {
                 // We clean the filename by removing the dir given
                 // to Tera so users don't have to prefix everytime
                 let parent_dir = dir.split_at(dir.find('*').unwrap()).0;
-                let filepath = path.to_string_lossy().replace(parent_dir, "")
-                                   .replace(r"\\", r"/");
+                let filepath = path.to_string_lossy().replace(r"\\", r"/").replace(parent_dir, "");
                 // we know the file exists so unwrap all the things
                 let mut f = File::open(path).unwrap();
                 let mut input = String::new();

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -42,7 +42,11 @@ impl Tera {
                 // We clean the filename by removing the dir given
                 // to Tera so users don't have to prefix everytime
                 let parent_dir = dir.split_at(dir.find('*').unwrap()).0;
-                let filepath = path.to_string_lossy().replace(r"\\", r"/").replace(parent_dir, "");
+                println!(" parent dir {:?}", parent_dir);
+                let filepath = path.to_string_lossy().replace(r"\\", r"/");
+                println!(" filepath {:?}", filepath);
+                let filepath = filepath.replace(parent_dir, "");
+                println!(" filepath {:?}", filepath);
                 // we know the file exists so unwrap all the things
                 let mut f = File::open(path).unwrap();
                 let mut input = String::new();

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -43,7 +43,7 @@ impl Tera {
                 // to Tera so users don't have to prefix everytime
                 let parent_dir = dir.split_at(dir.find('*').unwrap()).0;
                 println!(" parent dir {:?}", parent_dir);
-                let filepath = path.to_string_lossy().replace(r"\\", r"/");
+                let filepath = path.to_string_lossy().replace(r"\\\\", r"/");
                 println!(" filepath {:?}", filepath);
                 let filepath = filepath.replace(parent_dir, "");
                 println!(" filepath {:?}", filepath);

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -8,7 +8,6 @@ use glob::glob;
 use template::Template;
 use context::Context;
 use errors::TeraResult;
-use errors::TeraError;
 use errors;
 
 #[derive(Debug)]
@@ -36,17 +35,17 @@ impl Tera {
         // We are parsing all the templates on instantiation
         for entry in glob(dir).unwrap().filter_map(|e| e.ok()) {
             let path = entry.as_path();
-            println!("{:?}", path);
+            // println!("{:?}", path);
             // We only care about actual files
             if path.is_file() {
                 // We clean the filename by removing the dir given
                 // to Tera so users don't have to prefix everytime
                 let parent_dir = dir.split_at(dir.find('*').unwrap()).0;
-                println!(" parent dir {:?}", parent_dir);
+                // println!(" parent dir {:?}", parent_dir);
                 let filepath = path.to_string_lossy().replace("\\", "/");
-                println!(" filepath {:?}", filepath);
+                // println!(" filepath {:?}", filepath);
                 let filepath = filepath.replace(parent_dir, "");
-                println!(" filepath {:?}", filepath);
+                // println!(" filepath {:?}", filepath);
                 // we know the file exists so unwrap all the things
                 let mut f = File::open(path).unwrap();
                 let mut input = String::new();
@@ -55,7 +54,7 @@ impl Tera {
             }
         }
 
-        println!("templates {:?}", templates);
+        // println!("templates {:?}", templates);
 
         Tera {
             templates: templates

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -43,7 +43,7 @@ impl Tera {
                 // to Tera so users don't have to prefix everytime
                 let parent_dir = dir.split_at(dir.find('*').unwrap()).0;
                 println!(" parent dir {:?}", parent_dir);
-                let filepath = path.to_string_lossy().replace(r"\\\\", r"/");
+                let filepath = path.to_string_lossy().replace("\\", "/");
                 println!(" filepath {:?}", filepath);
                 let filepath = filepath.replace(parent_dir, "");
                 println!(" filepath {:?}", filepath);

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -51,15 +51,12 @@ impl Tera {
             }
         }
 
-        // println!("templates {:?}", templates);
-
         Tera {
             templates: templates
         }
     }
 
     pub fn render(&self, template_name: &str, data: Context) -> TeraResult<String> {
-        //let template = self.templates.get(template_name).unwrap(); // TODO error handling
         let template = match self.templates.get(template_name) {
             Some(tmpl) => tmpl,
             None => {

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -8,7 +8,8 @@ use glob::glob;
 use template::Template;
 use context::Context;
 use errors::TeraResult;
-
+use errors::TeraError;
+use errors;
 
 #[derive(Debug)]
 pub struct Tera {
@@ -55,7 +56,14 @@ impl Tera {
     }
 
     pub fn render(&self, template_name: &str, data: Context) -> TeraResult<String> {
-        let template = self.templates.get(template_name).unwrap(); // TODO error handling
+        //let template = self.templates.get(template_name).unwrap(); // TODO error handling
+        let template = match self.templates.get(template_name) {
+            Some(tmpl) => tmpl,
+            None => {
+                println!("error in render {}", template_name);
+                return Err(errors::template_not_found(template_name));
+            }
+        };
 
         // TODO: avoid cloning?
         template.render(data, self.templates.clone())


### PR DESCRIPTION
Usually we render template like 
```
render("foo/bar.html", Context::new())
```
we use '/', but on windows, tera generate dir file system hash with format like "foo\\bar.html".

This will meet panic when execute the render command. This pr solve this.