### PR TITLE
Add urlencode filter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ clippy = {version = "~0.0.77", optional = true}
 pest = "0.4"
 quick-error = "1.1.0"
 slug = "0.1"
+url = "1.2.0"
 
 [features]
 default = []

--- a/README.md
+++ b/README.md
@@ -246,3 +246,11 @@ Returns the length of an array or a string, 0 if the value is not an array.
 
 #### reverse
 Returns a reversed string or array
+
+#### urlencode
+Percent-encodes a string.
+
+Example: `{{ value | urlencode }}`
+If value is "/foo?a=b&c=d", the output will be "/foo%3Fa%3Db%26c%3Dd".
+
+Takes an optional argument of characters that shouldn't be percent-encoded (`/` by default). So, to encode slashes as well, you can do `{{ value | urlencode(safe: "") }}`. 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ extern crate pest;
 #[macro_use]
 extern crate quick_error;
 extern crate slug;
+extern crate url;
 
 
 mod errors;

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -92,6 +92,7 @@ impl Tera {
         self.register_filter("wordcount", string::wordcount);
         self.register_filter("replace", string::replace);
         self.register_filter("capitalize", string::capitalize);
+        self.register_filter("urlencode", string::urlencode);
 
         self.register_filter("first", array::first);
         self.register_filter("last", array::last);


### PR DESCRIPTION
Not sure if you're okay with a new dependency just for this.

I implemented most of the tests from https://github.com/django/django/blob/1ec1633cb294d8ce2a65ece6b56c258483596fba/tests/template_tests/filter_tests/test_urlencode.py, but `'fran\xe7ois & jill'` is not valid UTF-8, so Rust doesn't let me make that into a string literal.