### PR TITLE
Expose renderer directly to allow non-Context JSON object values.

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -23,6 +23,10 @@ quick_error! {
             display("Template `{}` wasn't found", name)
             description("template not found")
         }
+        InvalidValue(name: String) {
+            display("Expected the value to be an Object while rendering `{}`.", name)
+            description("invalid value")
+        }
         FilterNotFound(name: String) {
             display("Filter `{}` was not found in the context.", name)
             description("filter not found")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@
 // Needed by pest
 #![recursion_limit = "200"]
 
-
 #![cfg_attr(feature = "dev", feature(plugin))]
 #![cfg_attr(feature = "dev", plugin(clippy))]
 #![cfg_attr(feature = "dev", allow(block_in_if_condition_stmt, linkedlist))]
@@ -33,10 +32,10 @@ mod filters;
 mod testers;
 
 
-// Library exports. Template and Renderer are not meant to be used in your code
-// as they are generally unstable, internal APIs.
-pub use render::Renderer;
-pub use template::Template;
+// Library exports.
+
+// Template is meant to be used internally only but is exported for test/bench.
+#[doc(hidden)] pub use template::Template;
 pub use context::Context;
 pub use tera::Tera;
 pub use errors::{TeraResult, TeraError};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,9 +33,8 @@ mod filters;
 mod testers;
 
 
-// Library exports
-// Template and Rendered are not meant to be used in your code, only there for
-// bench/test of tera itself
+// Library exports. Template and Renderer are not meant to be used in your code
+// as they are generally unstable, internal APIs.
 pub use render::Renderer;
 pub use template::Template;
 pub use context::Context;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,8 +34,9 @@ mod testers;
 
 
 // Library exports
-// Template is not meant to be used in your code, only there for bench/test of
-// tera itself
+// Template and Rendered are not meant to be used in your code, only there for
+// bench/test of tera itself
+pub use render::Renderer;
 pub use template::Template;
 pub use context::Context;
 pub use tera::Tera;

--- a/src/render.rs
+++ b/src/render.rs
@@ -2,7 +2,7 @@ use std::collections::LinkedList;
 
 use serde_json::value::{Value, to_value};
 
-use context::{Context, ValueRender, ValueNumber, ValueTruthy};
+use context::{ValueRender, ValueNumber, ValueTruthy};
 use template::Template;
 use errors::TeraResult;
 use errors::TeraError::*;
@@ -56,11 +56,7 @@ pub struct Renderer<'a> {
 }
 
 impl<'a> Renderer<'a> {
-    pub fn new(tpl: &'a Template, tera: &'a Tera, context: Context) -> Renderer<'a> {
-        Renderer::new_with_json(tpl, tera, context.as_json())
-    }
-
-    pub fn new_with_json(tpl: &'a Template, tera: &'a Tera, context: Value) -> Renderer<'a> {
+    pub fn new(tpl: &'a Template, tera: &'a Tera, context: Value) -> Renderer<'a> {
         Renderer {
             template: tpl,
             tera: tera,

--- a/src/render.rs
+++ b/src/render.rs
@@ -57,10 +57,14 @@ pub struct Renderer<'a> {
 
 impl<'a> Renderer<'a> {
     pub fn new(tpl: &'a Template, tera: &'a Tera, context: Context) -> Renderer<'a> {
+        Renderer::new_with_json(tpl, tera, context.as_json())
+    }
+
+    pub fn new_with_json(tpl: &'a Template, tera: &'a Tera, context: Value) -> Renderer<'a> {
         Renderer {
             template: tpl,
             tera: tera,
-            context: context.as_json(),
+            context: context,
             for_loops: vec![],
         }
     }

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -4,6 +4,8 @@ use std::fs::File;
 use std::fmt;
 
 use glob::glob;
+use serde::Serialize;
+use serde_json::value::to_value;
 
 use template::Template;
 use filters::{FilterFn, string, array, common};
@@ -59,8 +61,22 @@ impl Tera {
 
     pub fn render(&self, template_name: &str, data: Context) -> TeraResult<String> {
         let template = try!(self.get_template(template_name));
-        let mut renderer = Renderer::new(template, self, data);
+        let mut renderer = Renderer::new(template, self, data.as_json());
 
+        renderer.render()
+    }
+
+    /// Renders a Serde JSON value.
+    pub fn render_value<T>(&self, template_name: &str, data: &T) -> TeraResult<String>
+        where T: Serialize
+    {
+        let value = to_value(data);
+        if !value.is_object() {
+            return Err(TeraError::InvalidValue(template_name.to_string()))
+        }
+
+        let template = try!(self.get_template(template_name));
+        let mut renderer = Renderer::new(template, self, value);
         renderer.render()
     }
 

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -59,6 +59,7 @@ impl Tera {
         tera
     }
 
+    /// Renders a Tera template given a `Context`.
     pub fn render(&self, template_name: &str, data: Context) -> TeraResult<String> {
         let template = try!(self.get_template(template_name));
         let mut renderer = Renderer::new(template, self, data.as_json());
@@ -66,8 +67,8 @@ impl Tera {
         renderer.render()
     }
 
-    /// Renders a Serde JSON value.
-    pub fn render_value<T>(&self, template_name: &str, data: &T) -> TeraResult<String>
+    /// Renders a Tera template given a `Serializeable` object.
+    pub fn value_render<T>(&self, template_name: &str, data: &T) -> TeraResult<String>
         where T: Serialize
     {
         let value = to_value(data);


### PR DESCRIPTION
It would be nice to render JSON values directly without first converting into a `Context` object. This is the way other Rust templating libraries work, and I think it makes the most sense. One way to do this is to export the Renderer type so that someone can call `Renderer::new_with_json` and then `render` directly. This is what this PR contributes.