### PR TITLE
Fix include whitespace (#72)

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -488,7 +488,7 @@ impl<'a> Renderer<'a> {
                     output.push_str(&try!(self.render_node(node)));
                 }
 
-                Ok(output.trim_left().to_string())
+                Ok(output.trim().to_string())
             },
             ImportMacro {tpl_name, name} => {
                 let tpl = try!(self.tera.get_template(&tpl_name));

--- a/tests/templates/included.html
+++ b/tests/templates/included.html
@@ -1,4 +1,4 @@
-<table>
+      <table>
         <thead>
           <th>User</th><th>Number of reviews</th>
         </thead>


### PR DESCRIPTION
Hi @Keats,

Got here from your call for participation on this week in rust.

After poking around, I realized that whitespace of the included file is fine (The first line should always be left_trimmed). 

However, I decided ``trim``  will be more proper to also truncate the ending whitespace

```rust
// Last node on the included file, we don't want the last \r\n 
Text("</td>\r\n        </tr>\r\n      </table>\r\n")
```

This PR fix #72

Cheers