### PR TITLE
Save a little clone, again

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -431,12 +431,12 @@ impl<'a> Renderer<'a> {
                 // We need to make a new context for the macro from the arguments given
                 // Return an error if we get some unknown params
                 let mut context = HashMap::new();
-                for (param_name, exp) in call_params.clone() {
+                for (param_name, exp) in &call_params {
                     if !params.contains(&param_name) {
                         let params_seen = call_params.keys().cloned().collect::<Vec<String>>();
                         bail!("Macro `{}` got `{:?}` for args but was expecting `{:?}` (order does not matter)", macro_name, params, params_seen);
                     }
-                    context.insert(param_name.to_string(), self.eval_expression(exp)?);
+                    context.insert(param_name.to_string(), self.eval_expression(exp.clone())?);
                 }
 
                 // Push this context to our stack of macro context so the renderer can pick variables
@@ -555,10 +555,10 @@ impl<'a> Renderer<'a> {
 
                     match self.template.blocks_definitions.get(&name) {
                         Some(b) => {
-                            match b[new_level].clone() {
-                                (tpl_name, Block { body, .. }) => {
-                                    self.blocks.push((name.clone(), new_level));
-                                    let has_macro = self.import_macros(tpl_name)?;
+                            match &b[new_level] {
+                                &(ref tpl_name, Block { ref body, .. }) => {
+                                    self.blocks.push((name, new_level));
+                                    let has_macro = self.import_macros(tpl_name.clone())?;
                                     let res = self.render_node(*body.clone());
                                     if has_macro {
                                         self.macros.pop();

--- a/src/template.rs
+++ b/src/template.rs
@@ -41,7 +41,7 @@ impl Template {
         let mut blocks = HashMap::new();
         // We find all those blocks at first so we don't need to do it for each render
         // Recursive because we can have blocks inside blocks
-        fn find_blocks(tpl_name: String, ast: LinkedList<Node>, blocks: &mut HashMap<String, Node>) -> Result<()> {
+        fn find_blocks(tpl_name: &str, ast: LinkedList<Node>, blocks: &mut HashMap<String, Node>) -> Result<()> {
             for node in ast {
                 match node {
                     Node::Block { ref name, ref body } => {
@@ -49,7 +49,7 @@ impl Template {
                             bail!("Block `{}` is duplicated", name);
                         }
                         blocks.insert(name.to_string(), node.clone());
-                        find_blocks(tpl_name.clone(), body.get_children(), blocks)?;
+                        find_blocks(tpl_name, body.get_children(), blocks)?;
                     },
                     _ => continue,
                 };
@@ -57,7 +57,7 @@ impl Template {
 
             Ok(())
         }
-        find_blocks(tpl_name.to_string(), ast.get_children(), &mut blocks)?;
+        find_blocks(tpl_name, ast.get_children(), &mut blocks)?;
 
         // We also find all macros defined/imported in the template file
         let mut macros = HashMap::new();


### PR DESCRIPTION
Don't know why the `tpl_name` in `Template::new`'s `find_blocks` function is unused.
Is it reserved for future use ? or it's something can be removed ?