### PR TITLE
Get rid of some `clone`s

### DIFF
--- a/src/filters/array.rs
+++ b/src/filters/array.rs
@@ -8,26 +8,30 @@ use errors::Result;
 /// Returns the first value of an array
 /// If the array is empty, returns empty string
 pub fn first(value: Value, _: HashMap<String, Value>) -> Result<Value> {
-    let arr = try_get_value!("first", "value", Vec<Value>, value);
+    let mut arr = try_get_value!("first", "value", Vec<Value>, value);
 
-    Ok(arr.first().cloned().unwrap_or_else(|| to_value(&"")))
+    if arr.is_empty() {
+        Ok(to_value(&""))
+    } else {
+        Ok(arr.swap_remove(0))
+    }
 }
 
 /// Returns the last value of an array
 /// If the array is empty, returns empty string
 pub fn last(value: Value, _: HashMap<String, Value>) -> Result<Value> {
-    let arr = try_get_value!("last", "value", Vec<Value>, value);
+    let mut arr = try_get_value!("last", "value", Vec<Value>, value);
 
-    Ok(arr.last().cloned().unwrap_or_else(|| to_value(&"")))
+    Ok(arr.pop().unwrap_or_else(|| to_value(&"")))
 }
 
 /// Joins all values in the array by the `sep` argument given
 /// If no separator is given, it will use `""` (empty string) as separator
 /// If the array is empty, returns empty string
-pub fn join(value: Value, args: HashMap<String, Value>) -> Result<Value> {
+pub fn join(value: Value, mut args: HashMap<String, Value>) -> Result<Value> {
     let arr = try_get_value!("join", "value", Vec<Value>, value);
-    let sep = match args.get("sep") {
-        Some(val) => try_get_value!("truncate", "sep", String, val.clone()),
+    let sep = match args.remove("sep") {
+        Some(val) => try_get_value!("truncate", "sep", String, val),
         None => "".to_string(),
     };
 

--- a/src/filters/common.rs
+++ b/src/filters/common.rs
@@ -20,11 +20,9 @@ pub fn length(value: Value, _: HashMap<String, Value>) -> Result<Value> {
 // Reverses the elements of an array or the characters in a string.
 pub fn reverse(value: Value, _: HashMap<String, Value>) -> Result<Value> {
     match value {
-        Value::Array(arr) => {
-            // Clone the array so that we don't mutate the original.
-            let mut rev = arr.clone();
-            rev.reverse();
-            Ok(to_value(&rev))
+        Value::Array(mut arr) => {
+            arr.reverse();
+            Ok(to_value(&arr))
         }
         Value::String(s) => Ok(to_value(&String::from_iter(s.chars().rev()))),
         _ => {
@@ -45,7 +43,7 @@ pub fn reverse(value: Value, _: HashMap<String, Value>) -> Result<Value> {
 ///
 /// Time formatting syntax is inspired from strftime and a full reference is available
 /// on [chrono docs](https://lifthrasiir.github.io/rust-chrono/chrono/format/strftime/index.html)
-pub fn date(value: Value, args: HashMap<String, Value>) -> Result<Value> {
+pub fn date(value: Value, mut args: HashMap<String, Value>) -> Result<Value> {
     let dt = match value {
         Value::I64(i) => NaiveDateTime::from_timestamp(i, 0),
         Value::U64(u) => NaiveDateTime::from_timestamp(u as i64, 0),
@@ -63,8 +61,8 @@ pub fn date(value: Value, args: HashMap<String, Value>) -> Result<Value> {
         }
     };
 
-    let format = match args.get("format") {
-        Some(val) => try_get_value!("date", "format", String, val.clone()),
+    let format = match args.remove("format") {
+        Some(val) => try_get_value!("date", "format", String, val),
         None => "%Y-%m-%d".to_string(),
     };
 

--- a/src/filters/number.rs
+++ b/src/filters/number.rs
@@ -8,10 +8,10 @@ use errors::Result;
 
 
 /// Returns a suffix if the value is greater or equal than 2. Suffix defaults to `s`
-pub fn pluralize(value: Value, args: HashMap<String, Value>) -> Result<Value> {
+pub fn pluralize(value: Value, mut args: HashMap<String, Value>) -> Result<Value> {
     let num = try_get_value!("pluralize", "value", f64, value);
-    let suffix = match args.get("suffix") {
-        Some(val) => try_get_value!("pluralize", "suffix", String, val.clone()),
+    let suffix = match args.remove("suffix") {
+        Some(val) => try_get_value!("pluralize", "suffix", String, val),
         None => "s".to_string(),
     };
 
@@ -26,14 +26,14 @@ pub fn pluralize(value: Value, args: HashMap<String, Value>) -> Result<Value> {
 /// `method` defaults to `common` which will round to the nearest number.
 /// `ceil` and `floor` are also available as method.
 /// `precision` defaults to `0`, meaning it will round to an integer
-pub fn round(value: Value, args: HashMap<String, Value>) -> Result<Value> {
+pub fn round(value: Value, mut args: HashMap<String, Value>) -> Result<Value> {
     let num = try_get_value!("round", "value", f64, value);
-    let method = match args.get("method") {
-        Some(val) => try_get_value!("round", "method", String, val.clone()),
+    let method = match args.remove("method") {
+        Some(val) => try_get_value!("round", "method", String, val),
         None => "common".to_string(),
     };
-    let precision = match args.get("precision") {
-        Some(val) => try_get_value!("round", "precision", i32, val.clone()),
+    let precision = match args.remove("precision") {
+        Some(val) => try_get_value!("round", "precision", i32, val),
         None => 0,
     };
     let multiplier = if precision == 0 { 1.0 } else { 10.0_f64.powi(precision) } ;

--- a/src/filters/string.rs
+++ b/src/filters/string.rs
@@ -39,10 +39,10 @@ pub fn trim(value: Value, _: HashMap<String, Value>) -> Result<Value> {
 }
 
 /// Truncates a string to the indicated length
-pub fn truncate(value: Value, args: HashMap<String, Value>) -> Result<Value> {
+pub fn truncate(value: Value, mut args: HashMap<String, Value>) -> Result<Value> {
     let s = try_get_value!("truncate", "value", String, value);
-    let length = match args.get("length") {
-        Some(l) => try_get_value!("truncate", "length", usize, l.clone()),
+    let length = match args.remove("length") {
+        Some(l) => try_get_value!("truncate", "length", usize, l),
         None => 255
     };
 
@@ -63,16 +63,16 @@ pub fn wordcount(value: Value, _: HashMap<String, Value>) -> Result<Value> {
 }
 
 /// Replaces given `from` substring with `to` string.
-pub fn replace(value: Value, args: HashMap<String, Value>) -> Result<Value> {
+pub fn replace(value: Value, mut args: HashMap<String, Value>) -> Result<Value> {
     let s = try_get_value!("replace", "value", String, value);
 
-    let from = match args.get("from") {
-        Some(val) => try_get_value!("replace", "from", String, val.clone()),
+    let from = match args.remove("from") {
+        Some(val) => try_get_value!("replace", "from", String, val),
         None => bail!("Filter `replace` expected an arg called `from`")
     };
 
-    let to = match args.get("to") {
-        Some(val) => try_get_value!("replace", "to", String, val.clone()),
+    let to = match args.remove("to") {
+        Some(val) => try_get_value!("replace", "to", String, val),
         None => bail!("Filter `replace` expected an arg called `to`")
     };
 
@@ -119,10 +119,10 @@ impl EncodeSet for UrlEncodeSet {
 }
 
 /// Percent-encodes reserved URI characters
-pub fn urlencode(value: Value, args: HashMap<String, Value>) -> Result<Value> {
+pub fn urlencode(value: Value, mut args: HashMap<String, Value>) -> Result<Value> {
     let s = try_get_value!("urlencode", "value", String, value);
-    let safe = match args.get("safe") {
-        Some(l) => try_get_value!("urlencode", "safe", String, l.clone()),
+    let safe = match args.remove("safe") {
+        Some(l) => try_get_value!("urlencode", "safe", String, l),
         None => "/".to_string(),
     };
 


### PR DESCRIPTION
Small optimisations:

1. A lot of filters consume `HashMap`s but unnecessarily clone the entries in them.
2. Filters which take array `Value`s do similar.
3. In `template.rs`, `Block`s and `Macro`s were cloned when a clone wasn't necessary.