### PR TITLE
s/LinkedList/VecDeque/g

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -1,4 +1,4 @@
-use std::collections::{LinkedList, HashMap};
+use std::collections::{VecDeque, HashMap};
 
 use serde_json::to_string_pretty;
 use serde_json::value::{Value, to_value};
@@ -325,7 +325,7 @@ impl<'a> Renderer<'a> {
     }
 
     // evaluates conditions and render bodies accordingly
-    fn render_if(&mut self, condition_nodes: LinkedList<Node>, else_node: Option<Box<Node>>) -> Result<String> {
+    fn render_if(&mut self, condition_nodes: VecDeque<Node>, else_node: Option<Box<Node>>) -> Result<String> {
         let mut skip_else = false;
         let mut output = String::new();
         for node in condition_nodes {

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, LinkedList};
+use std::collections::{HashMap, VecDeque};
 
 use parser::{parse, Node};
 use errors::{Result};
@@ -41,7 +41,7 @@ impl Template {
         let mut blocks = HashMap::new();
         // We find all those blocks at first so we don't need to do it for each render
         // Recursive because we can have blocks inside blocks
-        fn find_blocks(ast: LinkedList<Node>, blocks: &mut HashMap<String, Node>) -> Result<()> {
+        fn find_blocks(ast: VecDeque<Node>, blocks: &mut HashMap<String, Node>) -> Result<()> {
             for node in ast {
                 match node {
                     block @ Node::Block { .. } => {


### PR DESCRIPTION
master:

```
test bench_escape_html                         ... bench:         177 ns/iter (+/- 6)
test bench_parsing_basic_template              ... bench:      15,665 ns/iter (+/- 351)
test bench_parsing_with_inheritance_and_macros ... bench:      52,197 ns/iter (+/- 983)
test bench_rendering_basic_template            ... bench:      11,213 ns/iter (+/- 224)
test bench_rendering_inheritance_and_macros    ... bench:      23,724 ns/iter (+/- 678)
test bench_rendering_only_inheritance          ... bench:       6,041 ns/iter (+/- 116)
test bench_rendering_only_macro_call           ... bench:       4,048 ns/iter (+/- 107)
test bench_rendering_only_parent               ... bench:       3,627 ns/iter (+/- 64)
test bench_rendering_only_variable             ... bench:       3,254 ns/iter (+/- 72)
```

PR:

```
test bench_escape_html                         ... bench:         171 ns/iter (+/- 4)
test bench_parsing_basic_template              ... bench:      14,626 ns/iter (+/- 66)
test bench_parsing_with_inheritance_and_macros ... bench:      50,327 ns/iter (+/- 415)
test bench_rendering_basic_template            ... bench:      10,811 ns/iter (+/- 68)
test bench_rendering_inheritance_and_macros    ... bench:      22,450 ns/iter (+/- 283)
test bench_rendering_only_inheritance          ... bench:       5,888 ns/iter (+/- 58)
test bench_rendering_only_macro_call           ... bench:       3,805 ns/iter (+/- 42)
test bench_rendering_only_parent               ... bench:       3,651 ns/iter (+/- 26)
test bench_rendering_only_variable             ... bench:       3,323 ns/iter (+/- 14)
```

Not much of a difference on my box, but in general this should be a lot better.