### PR TITLE
Fix path prefix trimming on Windows.

### DIFF
--- a/src/tera.rs
+++ b/src/tera.rs
@@ -68,8 +68,8 @@ impl Tera {
                 // to Tera so users don't have to prefix everytime
                 let parent_dir = dir.split_at(dir.find('*').unwrap()).0;
                 let filepath = path.to_string_lossy()
-                    .replace("\\", "/") // change windows slash to forward slash
-                    .replace(parent_dir, "");
+                    .replace(parent_dir, "")
+                    .replace("\\", "/"); // change windows slash to forward slash
 
                 if let Err(e) = tera.add_file(Some(&filepath), path) {
                     errors += &format!("\n* {}", e);


### PR DESCRIPTION
Looks like template naming has been broken on Windows for quite a while via the `Tera::new(...)` function. This change resolves the issue. See https://github.com/SergioBenitez/Rocket/issues/169#issuecomment-277435725 for a full explanation of the problem. Please roll this change out to previous versions of Tera as well. 