### PR TITLE
Fix usage of join filter in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,7 +462,7 @@ If the array is empty, returns empty string.
 #### join
 Joins an array with a string.
 
-Example: `{{ value|join:" // " }}`
+Example: `{{ value| join(sep=" // ") }}`
 
 If value is the array `['a', 'b', 'c']`, the output will be the string "a // b // c".
 


### PR DESCRIPTION
I've tested the Django syntax as described in the documentation, but it gives me an "invalid syntax" error. Therefore I've changed it to the syntax of all other filters and that works.