### PR TITLE
feat: add base64 encode/decode filters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ url = "1"
 humansize = "1"
 # used in date format filter
 chrono = "0.3"
+# used in the base64 format filter
+rustc-serialize = "*"
 
 [dev-dependencies]
 serde_derive = "0.9"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ extern crate regex;
 extern crate url;
 extern crate humansize;
 extern crate chrono;
+extern crate rustc_serialize;
 
 mod errors;
 #[macro_use] mod macros;

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -411,6 +411,8 @@ impl Tera {
         self.register_filter("escape", string::escape_html);
         self.register_filter("slugify", string::slugify);
         self.register_filter("addslashes", string::addslashes);
+        self.register_filter("base64encode", string::base64encode);
+        self.register_filter("base64decode", string::base64decode);
 
         self.register_filter("first", array::first);
         self.register_filter("last", array::last);


### PR DESCRIPTION
This implements `base64encode` and `base64decode` filters.

This is done mainly for the use case of static stite generators such as gutenberg. For this cases, pretty often you need to implement more dynamic features that rely on current data and not in data available at the moment of the html render. For example, being able to manipulate content in a posts index based on the comparison of the post's date and the current browser's date in the client. However, when giving data processing control to the client, you can end up having difficulties handling multiline content or custom data. In such cases it's possible to use base64 to encode the data in the render stage and have the browser decode the data when needed.