### PR TITLE
Fixes handling loop variables

### DIFF
--- a/tests/templates/loops.html
+++ b/tests/templates/loops.html
@@ -22,8 +22,8 @@
     {% else %}
       <p>None of your friend reviewed this product</p>
     {% endif %}
-    {% for username, comment in comments %}
-        {{ username }}: {{ comment }}
+    {% for comment_username, comment in comments %}
+        {{ comment_username }}: {{ comment }}
     {% endfor %}
     <button>Buy!</button>
   </body>


### PR DESCRIPTION
Previously if you had loop like `for x_y, x in z` the key variable `x_y`
was resolved same as `x` because it's name is a prefix of a value
variable. This commit fixes the bug.