### PR TITLE
Calling a recursive macro inside a loop can break things

### DIFF
--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -31,3 +31,54 @@ fn test_can_load_template_files() {
     assert!(tera.get_template("tests/templates/basic.html").is_ok());
     assert!(tera.get_template("basic.html").is_ok());
 }
+
+
+#[test]
+fn test_nested_object() {
+    use tera::Context;
+
+    let parent = {
+        let mut p = Context::new();
+        p.add("parent", &None::<Context>);
+        p.add("label", &"Parent");
+        p
+    };
+
+    let child = {
+        let mut c = Context::new();
+        c.add("parent", &parent);
+        c.add("label", &"Child");
+        c
+    };
+
+    let context_failing = {
+        let mut c = Context::new();
+        c.add("objects", &vec![child.clone()]);
+        c
+    };
+
+    let context_passing = {
+        let mut c = Context::new();
+        c.add("obj", &child);
+        c
+    };
+    
+    let mut tera = Tera::default();
+
+    tera.add_template_files(vec![
+        (Path::new("tests/templates/macros.html"), Some("macros.html")),
+        (Path::new("tests/templates/use_nested_macro_failing.html"), Some("use_nested_macro_failing.html")),
+        (Path::new("tests/templates/use_nested_macro_passing.html"), Some("use_nested_macro_passing.html")),
+    ]).unwrap();
+
+    let out = tera.render("use_nested_macro_passing.html", &context_passing);
+
+    assert!(out.is_ok());
+
+    let out = tera.render("use_nested_macro_failing.html", &context_failing);
+
+    assert!(out.is_ok());
+
+
+
+}

--- a/tests/templates/macros.html
+++ b/tests/templates/macros.html
@@ -20,3 +20,11 @@
 {% macro dump(name) %}
     {{ __tera_context }}
 {% endmacro dump %}
+
+{% macro label_for(obj, sep) %}
+  {% if obj.parent %}
+    {{ self::label_for(obj=obj.parent, sep=sep) }}
+    {{sep}}
+  {% endif %}
+  {{obj.label}}
+{% endmacro label_for %}

--- a/tests/templates/use_nested_macro_failing.html
+++ b/tests/templates/use_nested_macro_failing.html
@@ -1,0 +1,6 @@
+{% import "macros.html" as macros %}
+
+{% for obj in objects %}
+  {% set formatted_label = macros::label_for(obj=obj, sep="|") %}
+  {{ formatted_label }}
+{% endfor %}

--- a/tests/templates/use_nested_macro_passing.html
+++ b/tests/templates/use_nested_macro_passing.html
@@ -1,0 +1,4 @@
+{% import "macros.html" as macros %}
+
+{% set formatted_label = macros::label_for(obj=obj, sep="|") %}
+{{ formatted_label }}


### PR DESCRIPTION
Adds a crashing test (sorry, I didn't dig too deeply into how tests were organized so I just put the test in `lib.rs`).

Test crashes with:
 ```
thread 'test_nested_object' has overflowed its stack
fatal runtime error: stack overflow
```

(Is it possible to capture SOs in cargo test?)

See [Issue 202](https://github.com/Keats/tera/issues/202)