### PR TITLE
Add json_encode filter to print any value as a JSON string

### DIFF
--- a/docs/content/docs/templates.md
+++ b/docs/content/docs/templates.md
@@ -544,6 +544,15 @@ Example: `{{ sections | get(key="posts/content") }}`
 Split a string into an array of strings, separated by a pattern given.
 Example: `{{ path | split(pat="/") }}`
 
+### json_encode
+Transforms any value into a JSON representation. This filter is better used together with `safe` or when automatic escape is disabled.
+
+Example: `{{ value | safe | json_encode() }}`
+
+It accepts a parameter `pretty` (boolean) to print a formatted JSON instead of a one-liner.
+
+Example: `{{ value | safe | json_encode(pretty=true) }}`
+
 ## Built-in tests
 
 Here are the currently built-in tests:

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -480,6 +480,7 @@ impl Tera {
         self.register_filter("length", common::length);
         self.register_filter("reverse", common::reverse);
         self.register_filter("date", common::date);
+        self.register_filter("json_encode", common::json_encode);
 
         self.register_filter("get", object::get);
     }


### PR DESCRIPTION
Hi,

this PR adds a json_encode() filter, to transform any Value into a JSON string.

I'm using it often in my projects, so I thought it could be useful to have it the core.
I kept testing and docs at the minimum to see if there is interest, but I can add more if needed.

I am using Tera with escaping off, so I'm not sure how it will react. It will probably break any value containing some sort of HTML. :) But it's meant to be used inside js templates or in <script> tags, so escaping should be disabled anyway.