### PR TITLE
Derive PartialEq for Context

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -11,7 +11,7 @@ use errors::{Result as TeraResult, ResultExt};
 ///
 /// Light wrapper around a `BTreeMap` for easier insertions of Serializable
 /// values
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Context {
     data: BTreeMap<String, Value>,
 }


### PR DESCRIPTION
This allows other crates to test functions that produce `Context` instances.