### PR TITLE
Allowed other type of quotes for strings #236

### DIFF
--- a/src/parser/tera.pest
+++ b/src/parser/tera.pest
@@ -10,7 +10,18 @@ float = @{
     )
 }
 // matches anything between 2 double quotes
-string  = @{ "\"" ~ ( ! ("\"") ~ any )* ~ "\""}
+double_quoted_string  = @{ "\"" ~ ( ! ("\"") ~ any )* ~ "\""}
+// matches anything between 2 single quotes
+single_quoted_string  = @{ "\'" ~ ( ! ("\'") ~ any )* ~ "\'"}
+// matches anything between 2 backquotes\backticks
+backquoted_quoted_string  = @{ "`" ~ ( ! ("`") ~ any )* ~ "`"}
+
+string = @{ 
+    double_quoted_string | 
+    single_quoted_string | 
+    backquoted_quoted_string 
+}
+
 boolean = { "true" | "false" }
 
 // -----------------------------------------------

--- a/src/parser/tests/lexer.rs
+++ b/src/parser/tests/lexer.rs
@@ -34,7 +34,10 @@ fn lex_float() {
 
 #[test]
 fn lex_string() {
-    let inputs = vec!["\"Blabla\"", "\"123\""];
+    let inputs = vec!["\"Blabla\"", "\"123\"", 
+                      "\'123\'", "\'This is still a string\'",
+                      "`this is backquted`", "`and this too`"
+                ];
     for i in inputs {
         assert_lex_rule!(Rule::string, i);
     }


### PR DESCRIPTION
Expanded the grammar with doublequotes and backticks and added them to the testcase.

I tried not to deviate from the description of the issue, but I'm not sure if it intended for `Rule::string` to _"decay"_ to the `Rule::text` when there is an unmatched quote(i.e `"\"string\""` is a `Rule::string`, but `"\"string"`(note the missing quote) is a `Rule::text`.

Note: it's a behaviour "inherited" from the `Rule::string` grammar.
