### PR TITLE
Add support for sort filter #233

### DIFF
--- a/docs/content/docs/templates.md
+++ b/docs/content/docs/templates.md
@@ -482,6 +482,43 @@ Returns the length of an array or a string, 0 if the value is not an array.
 ### reverse
 Returns a reversed string or array.
 
+### sort
+Sorts an array into ascending order.
+
+The values in the array must be a sortable type:
+- numbers are sorted by their numerical value.
+- strings are sorted in alphabetical order.
+- arrays are sorted by their length.
+- bools are sorted as if false=0 and true=1
+
+If you need to sort a list of structs or tuples, use the `attribute`
+argument to specify which field to sort by.
+
+Example:
+
+Given `people` is an array of Person
+
+```rust
+struct Name(String, String);
+
+struct Person {
+    name: Name,
+    age: u32
+}
+```
+
+The `attribute` argument can be used to sort by last name:
+
+```jinja2
+{{ people | sort(attribute="name.1") }}
+```
+
+or by age:
+
+```jinja2
+{{ people | sort(attribute="age") }}
+```
+
 ### urlencode
 Percent-encodes a string.
 

--- a/src/builtins/filters/array.rs
+++ b/src/builtins/filters/array.rs
@@ -1,8 +1,9 @@
 /// Filters operating on array
 use std::collections::HashMap;
+use std::cmp::Ordering;
 
 use serde_json::value::{Value, to_value};
-use context::ValueRender;
+use context::{ValueRender, get_json_pointer};
 use errors::Result;
 
 /// Returns the first value of an array
@@ -38,6 +39,53 @@ pub fn join(value: Value, args: HashMap<String, Value>) -> Result<Value> {
     // Convert all the values to strings before we join them together.
     let rendered = arr.iter().map(|val| val.render()).collect::<Vec<_>>();
     Ok(to_value(&rendered.join(&sep))?)
+}
+
+/// Sorts the array in ascending order.
+/// Use the 'attribute' argument to define a field to sort by.
+/// Set the 'reverse' argument to sort in descending order.
+pub fn sort(value: Value, args: HashMap<String, Value>) -> Result<Value> {
+    let mut arr = try_get_value!("sort", "value", Vec<Value>, value);
+    let reverse = try_get_value!("sort", "reverse", bool, args.get("reverse").unwrap_or(&false.into()));
+    let attribute = try_get_value!("sort", "attribute", String, args.get("attribute").unwrap_or(&"".into()));
+    let attribute = get_json_pointer(&attribute);
+
+    arr.sort_unstable_by(|a, b| {
+        value_cmp(
+            a.pointer(&attribute).unwrap_or(&Value::Null),
+            b.pointer(&attribute).unwrap_or(&Value::Null)
+        )
+    });
+    if reverse {
+        arr.reverse();
+    }
+
+    Ok(to_value(arr)?)
+}
+
+fn value_cmp(a: &Value, b: &Value) -> Ordering {
+    use Value::*;
+    use self::Ordering::*;
+    match (a, b) {
+        (&Null, &Null) => Equal,
+        (&Bool(ref a), &Bool(ref b)) => a.cmp(b),
+        (&Number(ref a), &Number(ref b)) => a.as_f64().unwrap().partial_cmp(&b.as_f64().unwrap()).unwrap(),
+        (&String(ref a), &String(ref b)) => a.cmp(b),
+        (&Array(ref a), &Array(ref b)) => a.len().cmp(&b.len()),
+        (&Object(ref a), &Object(ref b)) => a.len().cmp(&b.len()),
+        (a, b) => type_of(a).cmp(&type_of(b))
+    }
+}
+
+fn type_of(val: &Value) -> usize {
+    use Value::*;
+    match *val {
+        Null => 0,
+        Bool(_) => 1,
+        Number(_) => 2,
+        String(_) => 3,
+        Array(_) => 4, Object(_) => 5
+    }
 }
 
 #[cfg(test)]
@@ -104,5 +152,52 @@ mod tests {
         let result = join(to_value(&v).unwrap(), args);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), to_value(&"").unwrap());
+    }
+
+    #[test]
+    fn test_sort() {
+        let v = to_value(vec![3, 1, 2, 5, 4]).unwrap();
+        let args = HashMap::new();
+        let result = sort(v, args);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), to_value(vec![1, 2, 3, 4, 5]).unwrap());
+    }
+
+    #[test]
+    fn test_sort_descending() {
+        let v = to_value(vec![3, 1, 2, 5, 4]).unwrap();
+        let mut args = HashMap::new();
+        args.insert("reverse".to_string(), to_value(true).unwrap());
+
+        let result = sort(v, args);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), to_value(vec![5, 4, 3, 2, 1]).unwrap());
+    }
+
+    #[derive(Serialize)]
+    struct Foo {
+        a: i32,
+        b: i32
+    }
+
+    #[test]
+    fn test_sort_attribute() {
+        let v = to_value(vec![
+            Foo {a: 3, b: 5},
+            Foo {a: 2, b: 8},
+            Foo {a: 4, b: 7},
+            Foo {a: 1, b: 6},
+        ]).unwrap();
+        let mut args = HashMap::new();
+        args.insert("attribute".to_string(), to_value(&"a").unwrap());
+
+        let result = sort(v, args);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), to_value(vec![
+            Foo {a: 1, b: 6},
+            Foo {a: 2, b: 8},
+            Foo {a: 3, b: 5},
+            Foo {a: 4, b: 7},
+        ]).unwrap());
     }
 }

--- a/src/builtins/filters/array.rs
+++ b/src/builtins/filters/array.rs
@@ -1,10 +1,10 @@
 /// Filters operating on array
 use std::collections::HashMap;
-use std::cmp::Ordering;
 
 use serde_json::value::{Value, to_value};
 use context::{ValueRender, get_json_pointer};
 use errors::Result;
+use sort_utils::get_sort_strategy_for_type;
 
 /// Returns the first value of an array
 /// If the array is empty, returns empty string
@@ -64,114 +64,6 @@ pub fn sort(value: Value, args: HashMap<String, Value>) -> Result<Value> {
     let sorted = strategy.sort();
 
     Ok(sorted.into())
-}
-
-#[derive(PartialEq, PartialOrd, Default, Copy, Clone)]
-struct OrderedF64(f64);
-
-impl OrderedF64 {
-    fn new(n: f64) -> Result<Self> {
-        if n.is_finite() {
-            Ok(OrderedF64(n))
-        } else {
-            bail!("{} cannot be sorted", n)
-        }
-    }
-}
-
-impl Eq for OrderedF64 {}
-
-impl Ord for OrderedF64 {
-    fn cmp(&self, other: &OrderedF64) -> Ordering {
-        // unwrap is safe because self.0 is finite.
-        self.partial_cmp(other).unwrap()
-    }
-}
-
-#[derive(Default, Eq, PartialEq, Ord, PartialOrd, Copy, Clone)]
-struct ArrayLen(usize);
-
-trait GetSortKey: Ord + Sized + Clone {
-    fn get_sort_key(val: &Value) -> Result<Self>;
-}
-
-impl GetSortKey for OrderedF64 {
-    fn get_sort_key(val: &Value) -> Result<Self> {
-        let n = val.as_f64().ok_or(format!("expected number got {}", val))?;
-        OrderedF64::new(n)
-    }
-}
-
-impl GetSortKey for bool {
-    fn get_sort_key(val: &Value) -> Result<Self> {
-        val.as_bool().ok_or(format!("expected bool got {}", val).into())
-    }
-}
-
-impl GetSortKey for String {
-    fn get_sort_key(val: &Value) -> Result<Self> {
-        let str: Result<&str> = val.as_str().ok_or(format!("expected string got {}", val).into());
-        Ok(str?.to_owned())
-    }
-}
-
-impl GetSortKey for ArrayLen {
-    fn get_sort_key(val: &Value) -> Result<Self> {
-        let arr = val.as_array().ok_or(format!("expected array got {}", val))?;
-        Ok(ArrayLen(arr.len()))
-    }
-}
-
-#[derive(Default)]
-struct SortPairs<K: Ord> {
-    pairs: Vec<(Value, K)>
-}
-
-type Numbers = SortPairs<OrderedF64>;
-type Bools = SortPairs<bool>;
-type Strings = SortPairs<String>;
-type Arrays = SortPairs<ArrayLen>;
-
-impl<K: GetSortKey> SortPairs<K> {
-    fn try_add_pair(&mut self, val: &Value, key: &Value) -> Result<()> {
-        let key = K::get_sort_key(key)?;
-        self.pairs.push((val.clone(), key));
-        Ok(())
-    }
-
-    fn sort(&mut self) -> Vec<Value> {
-        self.pairs.sort_by_key(|a| a.1.clone());
-        self.pairs.iter()
-            .map(|a| a.0.clone())
-            .collect()
-    }
-}
-
-trait SortStrategy {
-    fn try_add_pair(&mut self, val: &Value, key: &Value) -> Result<()>;
-    fn sort(&mut self) -> Vec<Value>;
-}
-
-impl<K: GetSortKey> SortStrategy for SortPairs<K> {
-    fn try_add_pair(&mut self, val: &Value, key: &Value) -> Result<()> {
-        SortPairs::try_add_pair(self, val, key)
-    }
-
-    fn sort(&mut self) -> Vec<Value> {
-        SortPairs::sort(self)
-    }
-}
-
-fn get_sort_strategy_for_type(ty: &Value) -> Result<Box<SortStrategy>> {
-    use Value::*;
-    match *ty {
-        Null => bail!("Null is not a sortable value"),
-        Bool(_) => Ok(Box::new(Bools::default())),
-        Number(_) => Ok(Box::new(Numbers::default())),
-        String(_) => Ok(Box::new(Strings::default())),
-        Array(_) => Ok(Box::new(Arrays::default())),
-        Object(_) => bail!("Object is not a sortable value")
-    }
 }
 
 #[cfg(test)]

--- a/src/builtins/filters/array.rs
+++ b/src/builtins/filters/array.rs
@@ -45,12 +45,15 @@ pub fn join(value: Value, args: HashMap<String, Value>) -> Result<Value> {
 /// Use the 'attribute' argument to define a field to sort by.
 pub fn sort(value: Value, args: HashMap<String, Value>) -> Result<Value> {
     let mut arr = try_get_value!("sort", "value", Vec<Value>, value);
-    let attribute = try_get_value!("sort", "attribute", String, args.get("attribute").unwrap_or(&"".into()));
-    let ptr = get_json_pointer(&attribute);
-
     if arr.is_empty() {
         return Ok(arr.into());
     }
+
+    let attribute = try_get_value!("sort", "attribute", String, args.get("attribute").unwrap_or(&"".into()));
+    let ptr = match attribute.as_str() {
+        "" => "".to_string(),
+        s => get_json_pointer(s)
+    };
 
     let first = arr[0].pointer(&ptr).ok_or(format!("attribute '{}' does not reference a field", attribute))?;
     let mut strategy = get_sort_strategy_for_type(first)?;

--- a/src/builtins/filters/array.rs
+++ b/src/builtins/filters/array.rs
@@ -43,10 +43,8 @@ pub fn join(value: Value, args: HashMap<String, Value>) -> Result<Value> {
 
 /// Sorts the array in ascending order.
 /// Use the 'attribute' argument to define a field to sort by.
-/// Set the 'reverse' argument to sort in descending order.
 pub fn sort(value: Value, args: HashMap<String, Value>) -> Result<Value> {
     let mut arr = try_get_value!("sort", "value", Vec<Value>, value);
-    let reverse = try_get_value!("sort", "reverse", bool, args.get("reverse").unwrap_or(&false.into()));
     let attribute = try_get_value!("sort", "attribute", String, args.get("attribute").unwrap_or(&"".into()));
     let attribute = get_json_pointer(&attribute);
 
@@ -56,9 +54,6 @@ pub fn sort(value: Value, args: HashMap<String, Value>) -> Result<Value> {
             b.pointer(&attribute).unwrap_or(&Value::Null)
         )
     });
-    if reverse {
-        arr.reverse();
-    }
 
     Ok(to_value(arr)?)
 }
@@ -161,17 +156,6 @@ mod tests {
         let result = sort(v, args);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), to_value(vec![1, 2, 3, 4, 5]).unwrap());
-    }
-
-    #[test]
-    fn test_sort_descending() {
-        let v = to_value(vec![3, 1, 2, 5, 4]).unwrap();
-        let mut args = HashMap::new();
-        args.insert("reverse".to_string(), to_value(true).unwrap());
-
-        let result = sort(v, args);
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), to_value(vec![5, 4, 3, 2, 1]).unwrap());
     }
 
     #[derive(Serialize)]

--- a/src/context.rs
+++ b/src/context.rs
@@ -149,7 +149,11 @@ impl ValueTruthy for Value {
 /// Converts a dotted path to a json pointer one
 #[inline]
 pub fn get_json_pointer(key: &str) -> String {
-    ["/", &key.replace(".", "/")].join("")
+    if key == "" {
+        "".to_string()
+    } else {
+        ["/", &key.replace(".", "/")].join("")
+    }
 }
 
 #[cfg(test)]

--- a/src/context.rs
+++ b/src/context.rs
@@ -149,11 +149,7 @@ impl ValueTruthy for Value {
 /// Converts a dotted path to a json pointer one
 #[inline]
 pub fn get_json_pointer(key: &str) -> String {
-    if key == "" {
-        "".to_string()
-    } else {
-        ["/", &key.replace(".", "/")].join("")
-    }
+    ["/", &key.replace(".", "/")].join("")
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ mod context;
 mod parser;
 mod template;
 mod utils;
+mod sort_utils;
 mod builtins;
 mod renderer;
 mod tera;

--- a/src/sort_utils.rs
+++ b/src/sort_utils.rs
@@ -1,0 +1,111 @@
+use errors::Result;
+use serde_json::Value;
+use std::cmp::Ordering;
+
+#[derive(PartialEq, PartialOrd, Default, Copy, Clone)]
+pub struct OrderedF64(f64);
+
+impl OrderedF64 {
+    fn new(n: f64) -> Result<Self> {
+        if n.is_finite() {
+            Ok(OrderedF64(n))
+        } else {
+            bail!("{} cannot be sorted", n)
+        }
+    }
+}
+
+impl Eq for OrderedF64 {}
+
+impl Ord for OrderedF64 {
+    fn cmp(&self, other: &OrderedF64) -> Ordering {
+        // unwrap is safe because self.0 is finite.
+        self.partial_cmp(other).unwrap()
+    }
+}
+
+#[derive(Default, Eq, PartialEq, Ord, PartialOrd, Copy, Clone)]
+pub struct ArrayLen(usize);
+
+pub trait GetSortKey: Ord + Sized + Clone {
+    fn get_sort_key(val: &Value) -> Result<Self>;
+}
+
+impl GetSortKey for OrderedF64 {
+    fn get_sort_key(val: &Value) -> Result<Self> {
+        let n = val.as_f64().ok_or(format!("expected number got {}", val))?;
+        OrderedF64::new(n)
+    }
+}
+
+impl GetSortKey for bool {
+    fn get_sort_key(val: &Value) -> Result<Self> {
+        val.as_bool().ok_or(format!("expected bool got {}", val).into())
+    }
+}
+
+impl GetSortKey for String {
+    fn get_sort_key(val: &Value) -> Result<Self> {
+        let str: Result<&str> = val.as_str().ok_or(format!("expected string got {}", val).into());
+        Ok(str?.to_owned())
+    }
+}
+
+impl GetSortKey for ArrayLen {
+    fn get_sort_key(val: &Value) -> Result<Self> {
+        let arr = val.as_array().ok_or(format!("expected array got {}", val))?;
+        Ok(ArrayLen(arr.len()))
+    }
+}
+
+#[derive(Default)]
+pub struct SortPairs<K: Ord> {
+    pairs: Vec<(Value, K)>
+}
+
+type Numbers = SortPairs<OrderedF64>;
+type Bools = SortPairs<bool>;
+type Strings = SortPairs<String>;
+type Arrays = SortPairs<ArrayLen>;
+
+impl<K: GetSortKey> SortPairs<K> {
+    fn try_add_pair(&mut self, val: &Value, key: &Value) -> Result<()> {
+        let key = K::get_sort_key(key)?;
+        self.pairs.push((val.clone(), key));
+        Ok(())
+    }
+
+    fn sort(&mut self) -> Vec<Value> {
+        self.pairs.sort_by_key(|a| a.1.clone());
+        self.pairs.iter()
+            .map(|a| a.0.clone())
+            .collect()
+    }
+}
+
+pub trait SortStrategy {
+    fn try_add_pair(&mut self, val: &Value, key: &Value) -> Result<()>;
+    fn sort(&mut self) -> Vec<Value>;
+}
+
+impl<K: GetSortKey> SortStrategy for SortPairs<K> {
+    fn try_add_pair(&mut self, val: &Value, key: &Value) -> Result<()> {
+        SortPairs::try_add_pair(self, val, key)
+    }
+
+    fn sort(&mut self) -> Vec<Value> {
+        SortPairs::sort(self)
+    }
+}
+
+pub fn get_sort_strategy_for_type(ty: &Value) -> Result<Box<SortStrategy>> {
+    use Value::*;
+    match *ty {
+        Null => bail!("Null is not a sortable value"),
+        Bool(_) => Ok(Box::new(Bools::default())),
+        Number(_) => Ok(Box::new(Numbers::default())),
+        String(_) => Ok(Box::new(Strings::default())),
+        Array(_) => Ok(Box::new(Arrays::default())),
+        Object(_) => bail!("Object is not a sortable value")
+    }
+}

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -472,6 +472,7 @@ impl Tera {
         self.register_filter("first", array::first);
         self.register_filter("last", array::last);
         self.register_filter("join", array::join);
+        self.register_filter("sort", array::sort);
 
         self.register_filter("pluralize", number::pluralize);
         self.register_filter("round", number::round);


### PR DESCRIPTION
I'm submitting this as is to get some feedback.

Some things I'm currently unhappy with:
- An attribute that does not map to an actual field on the object fails silently.
- Sorting a list of numbers that contains NaN or infinity will cause a panic. (See all of the unwraps on line 72 of array.rs)