### PR TITLE
regression test for math on a number output by the length filter

### DIFF
--- a/tests/render-success/math_length.html
+++ b/tests/render-success/math_length.html
@@ -1,0 +1,1 @@
+{{ reviews|length - 1 }}

--- a/tests/render_success.rs
+++ b/tests/render_success.rs
@@ -1,0 +1,30 @@
+extern crate tera;
+#[macro_use]
+extern crate serde_derive;
+
+use tera::{Tera, Context, Result};
+
+mod common;
+use common::{Product, Review};
+
+
+fn render_tpl(tpl_name: &str) -> Result<String> {
+    let tera = Tera::new("tests/render-success/**/*").unwrap();
+    let mut context = Context::new();
+    context.add("product", &Product::new());
+    context.add("username", &"bob");
+    context.add("friend_reviewed", &true);
+    context.add("number_reviews", &2);
+    context.add("show_more", &true);
+    context.add("reviews", &vec![Review::new(), Review::new()]);
+
+    tera.render(tpl_name, &context)
+}
+
+
+#[test]
+fn test_render_math_length() {
+    let result = render_tpl("math_length.html");
+
+    assert_eq!(result.unwrap(), "1");
+}


### PR DESCRIPTION
I don't know tera well enough to find the cause of this regression from 0.10.10 to 0.11.beta, but here's a test case that reproduces it.