### PR TITLE
fix: don't truncate strings equal to length

### DIFF
--- a/src/builtins/filters/string.rs
+++ b/src/builtins/filters/string.rs
@@ -44,7 +44,7 @@ pub fn truncate(value: Value, args: HashMap<String, Value>) -> Result<Value> {
     };
 
     // Nothing to truncate?
-    if length > s.len() {
+    if length >= s.len() {
         return Ok(to_value(&s).unwrap());
     }
 


### PR DESCRIPTION
Fix a panic from the unwrap below when the string length is equal to the truncate length.