### PR TITLE
Accept title case boolean literals ("True" and "False")

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -175,7 +175,9 @@ fn parse_basic_expression(pair: Pair<Rule>) -> ExprVal {
         Rule::float => ExprVal::Float(pair.as_str().parse().unwrap()),
         Rule::boolean => match pair.as_str() {
             "true" => ExprVal::Bool(true),
+            "True" => ExprVal::Bool(true),
             "false" => ExprVal::Bool(false),
+            "False" => ExprVal::Bool(false),
             _ => unreachable!(),
         },
         Rule::test => ExprVal::Test(parse_test(pair)),

--- a/src/parser/tera.pest
+++ b/src/parser/tera.pest
@@ -22,7 +22,7 @@ string = @{
     backquoted_quoted_string
 }
 
-boolean = { "true" | "false" }
+boolean = { "true" | "false" | "True" | "False" }
 
 // -----------------------------------------------
 

--- a/src/parser/tests/lexer.rs
+++ b/src/parser/tests/lexer.rs
@@ -17,6 +17,14 @@ macro_rules! assert_lex_rule {
 }
 
 #[test]
+fn lex_boolean() {
+    let inputs = vec!["true", "false", "True", "False"];
+    for i in inputs {
+        assert_lex_rule!(Rule::boolean, i);
+    }
+}
+
+#[test]
 fn lex_int() {
     let inputs = vec!["-10", "0", "100", "250000"];
     for i in inputs {


### PR DESCRIPTION
As documented in http://jinja.pocoo.org/docs/2.10/templates/, Jinja2 supports lower case boolean literals as well as title case boolean literals.

In order to increase Tera's compatibility with Jinja2 respectively to reduce porting overhead when switching from Jinja2 to Tera this commit adds support for (python like) title case boolean literals to Tera.