### PR TITLE
Reworked the math evaluation to work on u64, i64 or f64

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -259,6 +259,8 @@ impl<'a> Renderer<'a> {
                 let v = self.lookup_ident(ident)?;
                 if v.is_i64() {
                     Number::from(v.as_i64().unwrap())
+                } else if v.is_u64() {
+                    Number::from(v.as_u64().unwrap())
                 } else if v.is_f64() {
                     Number::from_f64(v.as_f64().unwrap()).unwrap()
                 } else {
@@ -280,6 +282,10 @@ impl<'a> Renderer<'a> {
                             let ll = l.as_i64().unwrap();
                             let rr = r.as_i64().unwrap();
                             Number::from(ll * rr)
+                        } else if l.is_u64() && r.is_u64() {
+                            let ll = l.as_u64().unwrap();
+                            let rr = r.as_u64().unwrap();
+                            Number::from(ll * rr)
                         } else {
                             let ll = l.as_f64().unwrap();
                             let rr = r.as_f64().unwrap();
@@ -289,12 +295,21 @@ impl<'a> Renderer<'a> {
                     MathOperator::Div => {
                         let ll = l.as_f64().unwrap();
                         let rr = r.as_f64().unwrap();
-                        Number::from_f64(ll / rr).unwrap()
+                        let result = ll / rr;
+                        if result.is_nan() {
+                            bail!("Math Operation is NaN");
+                        } else {
+                            Number::from_f64(ll / rr).unwrap()
+                        }
                     },
                     MathOperator::Add => { 
                         if l.is_i64() && r.is_i64() {
                             let ll = l.as_i64().unwrap();
                             let rr = r.as_i64().unwrap();
+                            Number::from(ll + rr)
+                        } else if l.is_u64() && r.is_u64() {
+                            let ll = l.as_u64().unwrap();
+                            let rr = r.as_u64().unwrap();
                             Number::from(ll + rr)
                         } else {
                             let ll = l.as_f64().unwrap();
@@ -307,6 +322,10 @@ impl<'a> Renderer<'a> {
                             let ll = l.as_i64().unwrap();
                             let rr = r.as_i64().unwrap();
                             Number::from(ll - rr)
+                        } else if l.is_u64() && r.is_u64() {
+                            let ll = l.as_u64().unwrap();
+                            let rr = r.as_u64().unwrap();
+                            Number::from(ll - rr)
                         } else {
                             let ll = l.as_f64().unwrap();
                             let rr = r.as_f64().unwrap();
@@ -317,6 +336,10 @@ impl<'a> Renderer<'a> {
                         if l.is_i64() && r.is_i64() {
                             let ll = l.as_i64().unwrap();
                             let rr = r.as_i64().unwrap();
+                            Number::from(ll % rr)
+                        } else if l.is_u64() && r.is_u64() {
+                            let ll = l.as_u64().unwrap();
+                            let rr = r.as_u64().unwrap();
                             Number::from(ll % rr)
                         } else {
                             let ll = l.as_f64().unwrap();

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -291,18 +291,18 @@ impl<'a> Renderer<'a> {
                         } else {
                             let ll = l.as_f64().unwrap();
                             let rr = r.as_f64().unwrap();
-			    Some(Number::from_f64(ll * rr).unwrap())
+                            Some(Number::from_f64(ll * rr).unwrap())
                         }
                     },
                     MathOperator::Div => {
                         let ll = l.as_f64().unwrap();
                         let rr = r.as_f64().unwrap();
-			let res = ll / rr;
-			if res.is_nan() {
-			    None
-			} else {
+            			let res = ll / rr;
+            			if res.is_nan() {
+            			    None
+            			} else {
                             Some(Number::from_f64(res).unwrap())
-			}
+            			}
                     },
                     MathOperator::Add => { 
                         if l.is_i64() && r.is_i64() {
@@ -356,7 +356,7 @@ impl<'a> Renderer<'a> {
             _ => unreachable!("unimplemented"),
         };
 
-	Ok(result)
+        Ok(result)
     }
 
     /// Return the value of an expression as a bool
@@ -374,9 +374,9 @@ impl<'a> Renderer<'a> {
                         let r = self.eval_expr_as_number(rhs)?;
 
                         let (ll, rr) = match (l, r) {
-			    (Some(nl), Some(nr)) => (nl, nr),
+                            (Some(nl), Some(nr)) => (nl, nr),
                             _ => bail!("Comparison to NaN")
-			};
+                        };
 
                         match *operator {
                             LogicOperator::Gte => ll.as_f64().unwrap() >= rr.as_f64().unwrap(),
@@ -418,11 +418,11 @@ impl<'a> Renderer<'a> {
             }
             ExprVal::Math(_) | ExprVal::Int(_) | ExprVal::Float(_) => {
                 match self.eval_as_number(&expr.val) {
-		    Ok(Some(n)) => n.as_f64().unwrap() != 0.0,
-		    Ok(None) => false,
-		    Err(_) => false,
+                    Ok(Some(n)) => n.as_f64().unwrap() != 0.0,
+                    Ok(None) => false,
+                    Err(_) => false,
             	}
-	    }
+            }
             ExprVal::Test(ref test) => self.eval_test(test).unwrap_or(false),
             ExprVal::Bool(val) => val,
             ExprVal::String(ref string) => !string.is_empty(),

--- a/src/renderer/tests/basic.rs
+++ b/src/renderer/tests/basic.rs
@@ -374,6 +374,11 @@ fn render_for() {
             "{% for a in [1, true, 1.1, 'hello'] %}{{a}}{% endfor %}",
             "1true1.1hello"
         ),
+        // https://github.com/Keats/tera/issues/301
+        (
+            "{% set start = 0 %}{% set end = start + 3 %}{% for i in range(start=start, end=end) %}{{ i }}{% endfor%}",
+            "012"
+        )
     ];
 
     for (input, expected) in inputs {


### PR DESCRIPTION
#301 This is a basic fix for the problem. It just solves it. It also now panics on NaN operations (divide by 0), I am not sure if it is the expected behavior. I also haven't provided tests yet. 