### PR TITLE
Add as_str filter

### DIFF
--- a/docs/content/docs/templates.md
+++ b/docs/content/docs/templates.md
@@ -779,6 +779,11 @@ It accepts a parameter `pretty` (boolean) to print a formatted JSON instead of a
 
 Example: `{{ value | safe | json_encode(pretty=true) }}`
 
+### as_str
+Returns a string representation of the given value.
+
+Example: `{{ value | as_str }}`
+
 ### default
 Returns the default value given if the variable evaluated is not present in the context.
 

--- a/src/builtins/filters/common.rs
+++ b/src/builtins/filters/common.rs
@@ -8,6 +8,8 @@ use errors::Result;
 
 use chrono::{DateTime, FixedOffset, NaiveDate, NaiveDateTime, Utc};
 
+use context::ValueRender;
+
 // Returns the number of items in an array or the number of characters in a string.
 // Returns 0 if not an array or string.
 pub fn length(value: Value, _: HashMap<String, Value>) -> Result<Value> {
@@ -98,6 +100,11 @@ pub fn date(value: Value, mut args: HashMap<String, Value>) -> Result<Value> {
     Ok(to_value(&formatted.to_string())?)
 }
 
+// Returns the given value as a string.
+pub fn as_str(value: Value, _: HashMap<String, Value>) -> Result<Value> {
+    Ok(to_value(&value.render())?)
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
@@ -105,6 +112,21 @@ mod tests {
     use serde_json::value::to_value;
     use super::*;
     use chrono::{DateTime, Local};
+
+    #[test]
+    fn as_str_object() {
+        let map: HashMap<String, String> = HashMap::new();
+        let result = as_str(to_value(&map).unwrap(), HashMap::new());
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), to_value(&"[object]").unwrap());
+    }
+
+    #[test]
+    fn as_str_vec() {
+        let result = as_str(to_value(&vec![1, 2, 3, 4]).unwrap(), HashMap::new());
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), to_value(&"[1, 2, 3, 4]").unwrap());
+    }
 
     #[test]
     fn length_vec() {

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -508,6 +508,7 @@ impl Tera {
         self.register_filter("reverse", common::reverse);
         self.register_filter("date", common::date);
         self.register_filter("json_encode", common::json_encode);
+        self.register_filter("as_str", common::as_str);
 
         self.register_filter("get", object::get);
     }


### PR DESCRIPTION
Sorry for the wait, I thought I might be able to finish this before my trip, guess not.

Anywho I just used the `ValueRender` trait to convert it into a string. I added it to the registry, made some tests (probably wasn't needed), and added it to the `Built-in filters` section in the docs.