### PR TITLE
add support for 'is not' operator

### DIFF
--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -188,6 +188,8 @@ impl Expr {
 pub struct Test {
     /// Which expression is evaluated
     pub ident: String,
+    /// Is it using `not`?
+    pub negated: bool,
     /// Name of the test
     pub name: String,
     /// Any optional arg given to the test

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -152,7 +152,7 @@ fn parse_test(pair: Pair<Rule>) -> Test {
         };
     }
 
-    Test { ident: ident.unwrap(), name: name.unwrap(), args }
+    Test { ident: ident.unwrap(), negated: false, name: name.unwrap(), args }
 }
 
 fn parse_string_concat(pair: Pair<Rule>) -> ExprVal {
@@ -238,6 +238,11 @@ fn parse_basic_expression(pair: Pair<Rule>) -> ExprVal {
             _ => unreachable!(),
         },
         Rule::test => ExprVal::Test(parse_test(pair)),
+        Rule::test_not => {
+            let mut test = parse_test(pair);
+            test.negated = true;
+            ExprVal::Test(test)
+        },
         Rule::fn_call => ExprVal::FunctionCall(parse_fn_call(pair)),
         Rule::macro_call => ExprVal::MacroCall(parse_macro_call(pair)),
         Rule::string => ExprVal::String(replace_string_markers(pair.as_str())),
@@ -899,6 +904,7 @@ pub fn parse(input: &str) -> TeraResult<Vec<Node>> {
                     Rule::op_modulo => "`%`".to_string(),
                     Rule::filter => "a filter".to_string(),
                     Rule::test => "a test".to_string(),
+                    Rule::test_not => "a negated test".to_string(),
                     Rule::test_call => "a test call".to_string(),
                     Rule::test_arg => "a test argument (any expressions)".to_string(),
                     Rule::test_args => "a list of test arguments (any expressions)".to_string(),

--- a/src/parser/tera.pest
+++ b/src/parser/tera.pest
@@ -79,7 +79,7 @@ string_concat = { (fn_call | float | int | string | dotted_square_bracket_ident)
 /// We'll use precedence climbing on those in the parser phase
 
 // boolean first so they are not caught as identifiers
-basic_val  = _{ boolean | string_concat | test | macro_call | fn_call | dotted_square_bracket_ident | float | int | string }
+basic_val  = _{ boolean | string_concat | test_not | test | macro_call | fn_call | dotted_square_bracket_ident | float | int | string }
 basic_op   = _{ op_plus | op_minus | op_times | op_slash | op_modulo }
 basic_expr = { ("(" ~ basic_expr ~ ")" | basic_val) ~ (basic_op ~ basic_val)* }
 basic_expr_filter = { basic_expr ~ filter* }
@@ -124,6 +124,7 @@ macro_call      = { ident ~ "::" ~ ident ~ "(" ~ kwargs? ~ ")" }
 test_arg  = { logic_expr }
 test_args = !{ test_arg ~ ("," ~ test_arg)* }
 test_call = !{ ident ~ ("(" ~ test_args ~ ")")? }
+test_not  = { dotted_ident ~ "is" ~ "not" ~ test_call }
 test      = { dotted_ident ~ "is" ~ test_call }
 
 // -------------------------------------------------------

--- a/src/parser/tests/lexer.rs
+++ b/src/parser/tests/lexer.rs
@@ -261,6 +261,7 @@ fn lex_logic_val() {
         r#""hey""#,
         "a is defined",
         "a is defined(2)",
+        "a is not defined",
         "1 + 1",
         "1 + counts",
         "1 + counts.first",

--- a/src/parser/tests/parser.rs
+++ b/src/parser/tests/parser.rs
@@ -248,6 +248,21 @@ fn parse_variable_tag_simple_test() {
         ast[0],
         Node::VariableBlock(Expr::new(ExprVal::Test(Test {
             ident: "id".to_string(),
+            negated: false,
+            name: "defined".to_string(),
+            args: vec![],
+        },)))
+    );
+}
+
+#[test]
+fn parse_variable_tag_simple_negated_test() {
+    let ast = parse("{{ id is not defined }}").unwrap();
+    assert_eq!(
+        ast[0],
+        Node::VariableBlock(Expr::new(ExprVal::Test(Test {
+            ident: "id".to_string(),
+            negated: true,
             name: "defined".to_string(),
             args: vec![],
         },)))
@@ -262,6 +277,7 @@ fn parse_variable_tag_test_as_expression() {
         Node::VariableBlock(Expr::new(ExprVal::Logic(LogicExpr {
             lhs: Box::new(Expr::new(ExprVal::Test(Test {
                 ident: "user".to_string(),
+                negated: false,
                 name: "defined".to_string(),
                 args: vec![],
             },))),

--- a/src/renderer/processor.rs
+++ b/src/renderer/processor.rs
@@ -416,7 +416,12 @@ impl<'a> Processor<'a> {
 
         let found = self.lookup_ident(&test.ident).map(|found| found.clone().into_owned()).ok();
 
-        Ok(tester_fn.test(found.as_ref(), &tester_args)?)
+        let result = tester_fn.test(found.as_ref(), &tester_args)?;
+        if test.negated {
+            Ok(!result)
+        } else {
+            Ok(result)
+        }
     }
 
     fn eval_tera_fn_call(self: &mut Self, function_call: &'a FunctionCall) -> Result<Val<'a>> {

--- a/src/renderer/tests/basic.rs
+++ b/src/renderer/tests/basic.rs
@@ -99,6 +99,8 @@ fn render_variable_block_ident() {
         ("{{ name | length }}", "4"),
         ("{{ name is defined }}", "true"),
         ("{{ not name is defined }}", "false"),
+        ("{{ name is not defined }}", "false"),
+        ("{{ not name is not defined }}", "true"),
         ("{{ a is odd }}", "false"),
         ("{{ a is odd or b is odd  }}", "true"),
         ("{{ range(start=1, end=4) }}", "[1, 2, 3]"),


### PR DESCRIPTION
Closes issue #308 

I know this feature is controversial but it is mentioned in #331 so I tried to implement it (just because i love parsers <3).
Feel free to reject this.