### PR TITLE
Improve group_by output

### DIFF
--- a/src/builtins/filters/array.rs
+++ b/src/builtins/filters/array.rs
@@ -113,12 +113,17 @@ pub fn group_by(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
             if key_val.is_null() {
                 continue;
             }
-            let str_key = format!("{}", key_val);
+
+            let str_key = match key_val.as_str() {
+                Some(key) => key.to_owned(),
+                None => format!("{}", key_val),
+            };
 
             if let Some(vals) = grouped.get_mut(&str_key) {
                 vals.as_array_mut().unwrap().push(val);
                 continue;
             }
+
             grouped.insert(str_key, Value::Array(vec![val]));
         }
     }

--- a/src/renderer/tests/basic.rs
+++ b/src/renderer/tests/basic.rs
@@ -576,6 +576,28 @@ fn does_render_owned_for_loop_with_objects() {
 }
 
 #[test]
+fn does_render_owned_for_loop_with_objects_string_keys() {
+    let mut context = Context::new();
+    let data = json!([
+        {"id": 1, "group": "a"},
+        {"id": 2, "group": "b"},
+        {"id": 3, "group": "c"},
+        {"id": 4, "group": "a"},
+        {"id": 5, "group": "b"},
+        {"id": 6, "group": "c"},
+        {"id": 7, "group": "a"},
+        {"id": 8},
+        {"id": 9, "year": null},
+    ]);
+    context.insert("something", &data);
+
+    let tpl =
+        r#"{% for group, things in something | group_by(attribute="group") %}{{group}},{% endfor %}"#;
+    let expected = "a,b,c,";
+    assert_eq!(render_template(tpl, context).unwrap(), expected);
+}
+
+#[test]
 fn render_magic_variable_gets_all_contexts() {
     let mut context = Context::new();
     context.insert("html", &"<html>");


### PR DESCRIPTION
This PR fixes #383. It changes the behavior of the `group_by` filter to only stringify non-string keys. It includes a test case.