### PR TITLE
API enhancement proposals

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -132,6 +132,16 @@ impl ValueTruthy for Value {
     }
 }
 
+impl From<Context> for Value {
+    fn from(ctx: Context) -> Self {
+        let mut m = Map::new();
+        for (key, value) in ctx.data {
+            m.insert(key, value);
+        }
+        Value::Object(m)
+    }
+}
+
 /// Converts a dotted path to a json pointer one
 #[inline]
 pub fn get_json_pointer(key: &str) -> String {

--- a/src/context.rs
+++ b/src/context.rs
@@ -48,11 +48,7 @@ impl Context {
 
     /// Converts the context to a `serde_json::Value` consuming the context
     pub fn into_json(self) -> Value {
-        let mut m = Map::new();
-        for (key, value) in self.data {
-            m.insert(key, value);
-        }
-        Value::Object(m)
+        self.into()
     }
 }
 

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use globwalk::glob;
 use serde::Serialize;
 use serde_json::value::to_value;
+use serde_json::Value;
 
 use crate::builtins::filters::{array, common, number, object, string, Filter};
 use crate::builtins::functions::{self, Function};
@@ -17,7 +18,6 @@ use crate::errors::{Error, Result};
 use crate::renderer::Renderer;
 use crate::template::Template;
 use crate::utils::escape_html;
-use serde_json::Value;
 
 /// The escape function type definition
 pub type EscapeFn = fn(&str) -> String;

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -780,7 +780,7 @@ mod tests {
             ("c", "{% extends \"d\" %}"),
             ("d", ""),
         ])
-            .unwrap();
+        .unwrap();
 
         assert_eq!(
             tera.get_template("a").unwrap().parents,


### PR DESCRIPTION
Hi,

I'm using Tera to create a tool similar to Maven's Archetypes.  Like cargo generate, but much more flexible.  Thanks.

I'm essentially using a template directory, whereby the directories and file names themselves can contain variables, and the files contained within are contents for which variable replacement should occur.

I'm finding it very appealing to have the ability to set up a Tera instance that is essentially using each file in the template directory as a bunch of one-off templates.  With the current API, I'm restricted to either using a one_off Tera instance, or adding each file as a template itself, even though it will only be rendered once.

I have changed the render method to accept anything that can be turned into a Value.  This may cut down on having additional 'overload' methods for various types.  I didn't spend the time to see how perhaps if there is a way to `impl From<Serializable> for Value`, which would allow the removal of the render_value method.  I don't know if you had already considered this approach and decided it was too opaque for end users.  I also added render_template and render_string methods, and delegate to those from render itself.  I haven't spent any time testing any of this out, other than running existing unit tests.

This is more of a proposal than a pull request.  If you are interested in exploring these changes, I'd be happy to spend some more time on tests and docs, unless you wanted to take this and do whatever you'd like, if anything.

Cheers,

Jimmie