### PR TITLE
Add object builtin tester.

### DIFF
--- a/docs/content/docs/templates.md
+++ b/docs/content/docs/templates.md
@@ -882,6 +882,9 @@ Example:
 #### iterable
 Returns true if the given variable can be iterated over in Tera (ie is an array/tuple).
 
+#### object
+Returns true if the given variable is a hash (ie can be iterated over key, value).
+
 #### starting\_with
 Returns true if the given variable is a string starts with the arg given.
 

--- a/src/builtins/testers.rs
+++ b/src/builtins/testers.rs
@@ -112,6 +112,15 @@ pub fn iterable(value: Option<Value>, params: Vec<Value>) -> Result<bool> {
     Ok(value.unwrap().is_array())
 }
 
+/// Returns true if the given variable is a hash (ie can be iterated over key, value).
+/// Otherwise, returns false.
+pub fn object(value: Option<Value>, params: Vec<Value>) -> Result<bool> {
+    number_args_allowed("object", 0, params.len())?;
+    value_defined("object", &value)?;
+
+    Ok(value.unwrap().is_object())
+}
+
 // Helper function to extract string from an Option<Value> to remove boilerplate
 // with tester error handling
 fn extract_string<'a>(tester_name: &str, part: &str, value: Option<&'a Value>) -> Result<&'a str> {
@@ -181,7 +190,7 @@ mod tests {
     use std::collections::HashMap;
 
     use super::{
-        containing, defined, divisible_by, ending_with, iterable, matching, starting_with, string,
+        containing, defined, divisible_by, ending_with, iterable, object, matching, starting_with, string,
     };
 
     use serde_json::value::to_value;
@@ -225,6 +234,15 @@ mod tests {
         assert_eq!(iterable(Some(to_value(vec!["1"]).unwrap()), vec![]).unwrap(), true);
         assert_eq!(iterable(Some(to_value(1).unwrap()), vec![]).unwrap(), false);
         assert_eq!(iterable(Some(to_value("hello").unwrap()), vec![]).unwrap(), false);
+    }
+
+    #[test]
+    fn test_object() {
+        let mut h = HashMap::new();
+        h.insert("a", 1);
+        assert_eq!(object(Some(to_value(h).unwrap()), vec![]).unwrap(), true);
+        assert_eq!(object(Some(to_value(1).unwrap()), vec![]).unwrap(), false);
+        assert_eq!(object(Some(to_value("hello").unwrap()), vec![]).unwrap(), false);
     }
 
     #[test]


### PR DESCRIPTION
Hello I missed a builtin tester to check if a variable in context can be iterated over key value (if it is a hash). I made a local implementation of it in my project but this seems like something more people can use :)

I'm a rust beginner so let me know if there's anything I can improve to get this merged.