### PR TITLE
Implemented feature from issue #395 ("else" case in for loops)

### DIFF
--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -296,7 +296,7 @@ pub struct Forloop {
     /// What's in the forloop itself
     pub body: Vec<Node>,
     /// The body to execute in case of an empty object
-    pub empty_body: Option<Vec<Node>>
+    pub empty_body: Option<Vec<Node>>,
 }
 
 /// An if/elif/else condition with their respective body

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -295,6 +295,8 @@ pub struct Forloop {
     pub container: Expr,
     /// What's in the forloop itself
     pub body: Vec<Node>,
+    /// The body to execute in case of an empty object
+    pub empty_body: Option<Vec<Node>>
 }
 
 /// An if/elif/else condition with their respective body

--- a/src/parser/tera.pest
+++ b/src/parser/tera.pest
@@ -197,7 +197,7 @@ raw        = !{ raw_tag ~ raw_text ~ endraw_tag }
 
 filter_section = !{ filter_tag ~ filter_section_content* ~ endfilter_tag }
 
-forloop = ${ for_tag ~ for_content* ~ endfor_tag }
+forloop = ${ for_tag ~ for_content* ~ (else_tag ~ for_content*)* ~ endfor_tag }
 
 macro_if          = ${ if_tag ~ macro_content* ~ (elif_tag ~ macro_content*)* ~ (else_tag ~ macro_content*)? ~ endif_tag }
 block_if          = ${ if_tag ~ block_content* ~ (elif_tag ~ block_content*)* ~ (else_tag ~ block_content*)? ~ endif_tag }

--- a/src/parser/tests/parser.rs
+++ b/src/parser/tests/parser.rs
@@ -639,6 +639,7 @@ fn parse_value_forloop() {
                     vec![FunctionCall { name: "reverse".to_string(), args: HashMap::new() },],
                 ),
                 body: vec![Node::Text("A".to_string())],
+                empty_body: None,
             },
             end_ws,
         )
@@ -664,6 +665,7 @@ fn parse_key_value_forloop() {
                     args: HashMap::new(),
                 },)),
                 body: vec![Node::Text("A".to_string())],
+                empty_body: None,
             },
             end_ws,
         )
@@ -689,6 +691,33 @@ fn parse_value_forloop_array() {
                     Expr::new(ExprVal::Int(2)),
                 ])),
                 body: vec![Node::Text("A".to_string())],
+                empty_body: None,
+            },
+            end_ws,
+        )
+    );
+}
+
+#[test]
+fn parse_value_forloop_empty() {
+    let ast = parse("{% for item in [1,2,] %}A{% else %}B{%- endfor %}").unwrap();
+    let start_ws = WS::default();
+    let mut end_ws = WS::default();
+    end_ws.left = true;
+
+    assert_eq!(
+        ast[0],
+        Node::Forloop(
+            start_ws,
+            Forloop {
+                key: None,
+                value: "item".to_string(),
+                container: Expr::new(ExprVal::Array(vec![
+                    Expr::new(ExprVal::Int(1)),
+                    Expr::new(ExprVal::Int(2)),
+                ])),
+                body: vec![Node::Text("A".to_string())],
+                empty_body: Some(vec![Node::Text("B".to_string())]),
             },
             end_ws,
         )
@@ -748,6 +777,7 @@ fn parse_break() {
                 value: "item".to_string(),
                 container: Expr::new(ExprVal::Ident("items".to_string())),
                 body: vec![Node::Break(WS { left: false, right: true }),],
+                empty_body: None,
             },
             for_ws,
         )
@@ -767,6 +797,7 @@ fn parse_continue() {
                 value: "item".to_string(),
                 container: Expr::new(ExprVal::Ident("items".to_string())),
                 body: vec![Node::Continue(WS { left: false, right: true }),],
+                empty_body: None,
             },
             for_ws,
         )

--- a/src/parser/tests/whitespace.rs
+++ b/src/parser/tests/whitespace.rs
@@ -104,6 +104,7 @@ fn handle_ws_both_sides_for_forloop_tag_and_remove_empty_node() {
                 container: Expr::new(ExprVal::Int(1)),
                 // not valid but we don't care about it here
                 body: vec![Node::Text("   ".to_string()), Node::Text("hey   ".to_string())],
+                empty_body: None,
             },
             end_ws,
         ),
@@ -121,6 +122,7 @@ fn handle_ws_both_sides_for_forloop_tag_and_remove_empty_node() {
                     container: Expr::new(ExprVal::Int(1)),
                     // not valid but we don't care about it here
                     body: vec![Node::Text("hey".to_string())],
+                    empty_body: None,
                 },
                 end_ws,
             ),

--- a/src/renderer/processor.rs
+++ b/src/renderer/processor.rs
@@ -172,6 +172,7 @@ impl<'a> Processor<'a> {
 
         let for_loop_name = &for_loop.value;
         let for_loop_body = &for_loop.body;
+        let for_loop_empty_body = &for_loop.empty_body;
 
         let for_loop = match *container_val {
             Value::Array(_) => {
@@ -210,6 +211,14 @@ impl<'a> Processor<'a> {
         };
 
         let len = for_loop.len();
+        if len == 0 {
+            if let Some(empty_body) = for_loop_empty_body {
+                return Ok(self.render_body(&empty_body)?);
+            } else {
+                return Ok("".to_string());
+            }
+        }
+
         self.call_stack.push_for_loop_frame(for_loop_name, for_loop);
 
         let mut output = String::with_capacity(len * 20);

--- a/src/renderer/processor.rs
+++ b/src/renderer/processor.rs
@@ -222,12 +222,10 @@ impl<'a> Processor<'a> {
         };
 
         let len = for_loop.len();
-        if len == 0 {
-            if let Some(empty_body) = for_loop_empty_body {
-                return Ok(self.render_body(&empty_body)?);
-            } else {
-                return Ok("".to_string());
-            }
+        match (len, for_loop_empty_body) {
+            (0, Some(empty_body)) => return Ok(self.render_body(&empty_body)?),
+            (0, _) => return Ok("".to_string()),
+            (_, _) => (),
         }
 
         self.call_stack.push_for_loop_frame(for_loop_name, for_loop);

--- a/src/renderer/processor.rs
+++ b/src/renderer/processor.rs
@@ -168,11 +168,22 @@ impl<'a> Processor<'a> {
             ))),
         };
 
-        let container_val = self.safe_eval_expression(&for_loop.container)?;
-
         let for_loop_name = &for_loop.value;
         let for_loop_body = &for_loop.body;
         let for_loop_empty_body = &for_loop.empty_body;
+
+        let container_val = if let Ok(val) = self.safe_eval_expression(&for_loop.container) {
+            val
+        } else {
+            if let Some(empty_body) = for_loop_empty_body {
+                return Ok(self.render_body(&empty_body)?);
+            } else {
+                return Err(Error::msg(format!(
+                    "Tried to iterate undefined container `{}`. To treat undefined containers the same as empty ones, explicitly define an {{% else %}} block within the for loop",
+                    container_name,
+                )));
+            }
+        };
 
         let for_loop = match *container_val {
             Value::Array(_) => {

--- a/src/renderer/tests/basic.rs
+++ b/src/renderer/tests/basic.rs
@@ -500,9 +500,9 @@ fn render_for() {
             "hello"
         ),
         (
-            "{% for a in undefined_variable %}{{a}}{% else %}hello{% endfor %}",
+            "{% for a in undefined_variable | default(value=[]) %}{{a}}{% else %}hello{% endfor %}",
             "hello"
-        ),
+        ),        
         (
             "{% for a in [] %}{{a}}{% else %}{% if 1 == 2 %}A{% else %}B{% endif %}{% endfor %}",
             "B"

--- a/src/renderer/tests/basic.rs
+++ b/src/renderer/tests/basic.rs
@@ -493,7 +493,16 @@ fn render_for() {
         (
             "{% set start = 0 %}{% set end = start + 3 %}{% for i in range(start=start, end=end) %}{{ i }}{% endfor%}",
             "012"
-        )
+        ),
+        // https://github.com/Keats/tera/issues/395
+        (
+            "{% for a in [] %}{{a}}{% else %}hello{% endfor %}",
+            "hello"
+        ),
+        (
+            "{% for a in [] %}{{a}}{% else %}{% if 1 == 2 %}A{% else %}B{% endif %}{% endfor %}",
+            "B"
+        ),
     ];
 
     for (input, expected) in inputs {

--- a/src/renderer/tests/basic.rs
+++ b/src/renderer/tests/basic.rs
@@ -500,6 +500,10 @@ fn render_for() {
             "hello"
         ),
         (
+            "{% for a in undefined_variable %}{{a}}{% else %}hello{% endfor %}",
+            "hello"
+        ),
+        (
             "{% for a in [] %}{{a}}{% else %}{% if 1 == 2 %}A{% else %}B{% endif %}{% endfor %}",
             "B"
         ),

--- a/src/renderer/tests/errors.rs
+++ b/src/renderer/tests/errors.rs
@@ -177,6 +177,22 @@ fn error_when_using_variable_set_in_included_templates_outside() {
     );
 }
 
+// https://github.com/Keats/tera/issues/395
+#[test]
+fn error_when_iterating_over_undefined_container_unless_explicit_else_tag() {
+    let mut tera = Tera::default();
+    tera.add_raw_templates(vec![
+        ("forloop", r#"{% for a in undefined_container %}{{a}}{% endfor %}"#),
+    ])
+    .unwrap();
+    let result = tera.render("forloop", Context::new());
+
+    assert_eq!(
+        result.unwrap_err().source().unwrap().to_string(),
+        "Tried to iterate undefined container `undefined_container`. To treat undefined containers the same as empty ones, explicitly define an {% else %} block within the for loop"
+    );
+}
+
 // https://github.com/Keats/tera/issues/344
 // Yes it is as silly as it sounds
 #[test]

--- a/src/renderer/tests/errors.rs
+++ b/src/renderer/tests/errors.rs
@@ -177,23 +177,6 @@ fn error_when_using_variable_set_in_included_templates_outside() {
     );
 }
 
-// https://github.com/Keats/tera/issues/395
-#[test]
-fn error_when_iterating_over_undefined_container_unless_explicit_else_tag() {
-    let mut tera = Tera::default();
-    tera.add_raw_templates(vec![(
-        "forloop",
-        r#"{% for a in undefined_container %}{{a}}{% endfor %}"#,
-    )])
-    .unwrap();
-    let result = tera.render("forloop", Context::new());
-
-    assert_eq!(
-        result.unwrap_err().source().unwrap().to_string(),
-        "Tried to iterate undefined container `undefined_container`. To treat undefined containers the same as empty ones, explicitly define an {% else %} block within the for loop"
-    );
-}
-
 // https://github.com/Keats/tera/issues/344
 // Yes it is as silly as it sounds
 #[test]

--- a/src/renderer/tests/errors.rs
+++ b/src/renderer/tests/errors.rs
@@ -181,9 +181,10 @@ fn error_when_using_variable_set_in_included_templates_outside() {
 #[test]
 fn error_when_iterating_over_undefined_container_unless_explicit_else_tag() {
     let mut tera = Tera::default();
-    tera.add_raw_templates(vec![
-        ("forloop", r#"{% for a in undefined_container %}{{a}}{% endfor %}"#),
-    ])
+    tera.add_raw_templates(vec![(
+        "forloop",
+        r#"{% for a in undefined_container %}{{a}}{% endfor %}"#,
+    )])
     .unwrap();
     let result = tera.render("forloop", Context::new());
 

--- a/src/sort_utils.rs
+++ b/src/sort_utils.rs
@@ -98,7 +98,7 @@ impl<K: GetSortKey> SortStrategy for SortPairs<K> {
     }
 }
 
-pub fn get_sort_strategy_for_type(ty: &Value) -> Result<Box<SortStrategy>> {
+pub fn get_sort_strategy_for_type(ty: &Value) -> Result<Box<dyn SortStrategy>> {
     use crate::Value::*;
     match *ty {
         Null => Err(Error::msg("Null is not a sortable value")),


### PR DESCRIPTION
Fixes #395 

I've implemented the functionality requested in issue #395 along with some test cases that cover the code.

I've made the following decisions that I'd like some feedback on:

### Renamed {% empty %} -> {% else %}
I've taken the liberty of naming the fail-case "else" instead of "empty" since I feel like it better conveys the control flow, "empty" feels a little ambiguous, at least as someone not familiar with Django. 

### Silently render _else_ case if iterating over undefined variable
As requested, this functionality also covers the case where you attempt to iterate over an undefined variable, defaulting to the _else_ block, and throwing an error if no _else_ block is defined.

This will fail to compile:
```
{% for a in undefined_variable %}
    {{a}}
{% endfor %}
```
and yield the error:  `Tried to iterate undefined container 'undefined_variable'. To treat undefined containers the same as empty ones, explicitly define an {% else %} block within the for loop`


This will render "hello world"
```
{% for a in undefined_variable %}
    {{a}}
{% else %}
    hello world
{% endfor %}
```

I'm unsure of whether this is a good compromise, and if the "undefined" case should even be covered by the _else_ case, or if additional checks by the user should be required in that case.