### PR TITLE
Add whitespace control to expressions

### DIFF
--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -317,7 +317,7 @@ pub enum Node {
     /// Some actual text
     Text(String),
     /// A `{{ }}` block
-    VariableBlock(Expr),
+    VariableBlock(WS, Expr),
     /// A `{% macro hello() %}...{% endmacro %}`
     MacroDefinition(WS, MacroDefinition, WS),
 

--- a/src/parser/tera.pest
+++ b/src/parser/tera.pest
@@ -139,8 +139,8 @@ test      = { dotted_ident ~ "is" ~ test_call }
 /// TERA
 
 // All the blocks that Tera recognises
-variable_start = _{ "{{" }
-variable_end   = _{ "}}" }
+variable_start = _{ "{{-" | "{{" }
+variable_end   = _{ "-}}" | "}}" }
 // whitespace control
 tag_start      = { "{%-" | "{%" }
 tag_end        = { "-%}" | "%}" }

--- a/src/parser/tera.pest
+++ b/src/parser/tera.pest
@@ -139,8 +139,8 @@ test      = { dotted_ident ~ "is" ~ test_call }
 /// TERA
 
 // All the blocks that Tera recognises
-variable_start = _{ "{{-" | "{{" }
-variable_end   = _{ "-}}" | "}}" }
+variable_start = { "{{-" | "{{" }
+variable_end   = { "-}}" | "}}" }
 // whitespace control
 tag_start      = { "{%-" | "{%" }
 tag_end        = { "-%}" | "%}" }

--- a/src/parser/tests/errors.rs
+++ b/src/parser/tests/errors.rs
@@ -19,7 +19,7 @@ fn invalid_number() {
         "{{ 1.2.2 }}",
         &[
             "1:7",
-            "expected `or`, `and`, `<=`, `>=`, `<`, `>`, `==`, `!=`, `+`, `-`, `*`, `/`, `%`, or a filter"
+            "expected `or`, `and`, `<=`, `>=`, `<`, `>`, `==`, `!=`, `+`, `-`, `*`, `/`, `%`, a filter, or a variable end (`}}`)"
         ],
     );
 }
@@ -35,7 +35,7 @@ fn wrong_start_block() {
         "{{ if true %}",
         &[
             "1:7",
-            "expected `or`, `and`, `<=`, `>=`, `<`, `>`, `==`, `!=`, `+`, `-`, `*`, `/`, `%`, or a filter"
+            "expected `or`, `and`, `<=`, `>=`, `<`, `>`, `==`, `!=`, `+`, `-`, `*`, `/`, `%`, a filter, or a variable end (`}}`)"
         ],
     );
 }
@@ -57,7 +57,7 @@ fn unterminated_variable_block() {
         "{{ hey",
         &[
             "1:7",
-            "expected `or`, `and`, `<=`, `>=`, `<`, `>`, `==`, `!=`, `+`, `-`, `*`, `/`, `%`, or a filter"
+            "expected `or`, `and`, `<=`, `>=`, `<`, `>`, `==`, `!=`, `+`, `-`, `*`, `/`, `%`, a filter, or a variable end (`}}`)"
         ],
     );
 }
@@ -155,7 +155,7 @@ fn invalid_operator() {
         "{{ hey =! }}",
         &[
             "1:8",
-            "expected `or`, `and`, `<=`, `>=`, `<`, `>`, `==`, `!=`, `+`, `-`, `*`, `/`, `%`, or a filter"
+            "expected `or`, `and`, `<=`, `>=`, `<`, `>`, `==`, `!=`, `+`, `-`, `*`, `/`, `%`, a filter, or a variable end (`}}`)"
         ],
     );
 }
@@ -212,7 +212,7 @@ fn invalid_macro_call() {
         "{{ my:macro() }}",
         &[
             "1:6",
-            "expected `or`, `and`, `<=`, `>=`, `<`, `>`, `==`, `!=`, `+`, `-`, `*`, `/`, `%`, or a filter"
+            "expected `or`, `and`, `<=`, `>=`, `<`, `>`, `==`, `!=`, `+`, `-`, `*`, `/`, `%`, a filter, or a variable end (`}}`)"
         ],
     );
 }

--- a/src/parser/tests/parser.rs
+++ b/src/parser/tests/parser.rs
@@ -55,13 +55,22 @@ fn parse_import_macro() {
 #[test]
 fn parse_variable_with_whitespace_trimming() {
     let ast = parse("{{- id }}").unwrap();
-    assert_eq!(ast[0], Node::VariableBlock(WS { left: true, right: false }, Expr::new(ExprVal::Ident("id".to_string()))),);
+    assert_eq!(
+        ast[0],
+        Node::VariableBlock(
+            WS { left: true, right: false },
+            Expr::new(ExprVal::Ident("id".to_string()))
+        ),
+    );
 }
 
 #[test]
 fn parse_variable_tag_ident() {
     let ast = parse("{{ id }}").unwrap();
-    assert_eq!(ast[0], Node::VariableBlock(WS::default(), Expr::new(ExprVal::Ident("id".to_string()))),);
+    assert_eq!(
+        ast[0],
+        Node::VariableBlock(WS::default(), Expr::new(ExprVal::Ident("id".to_string()))),
+    );
 }
 
 #[test]
@@ -72,13 +81,16 @@ fn parse_variable_tag_ident_with_simple_filters() {
 
     assert_eq!(
         ast[0],
-        Node::VariableBlock(WS::default(), Expr::with_filters(
-            ExprVal::Ident("arr".to_string()),
-            vec![
-                FunctionCall { name: "first".to_string(), args: HashMap::new() },
-                FunctionCall { name: "join".to_string(), args: join_args },
-            ],
-        ))
+        Node::VariableBlock(
+            WS::default(),
+            Expr::with_filters(
+                ExprVal::Ident("arr".to_string()),
+                vec![
+                    FunctionCall { name: "first".to_string(), args: HashMap::new() },
+                    FunctionCall { name: "join".to_string(), args: join_args },
+                ],
+            )
+        )
     );
 }
 
@@ -87,7 +99,10 @@ fn parse_variable_tag_lit() {
     let ast = parse("{{ 2 }}{{ 3.14 }}{{ \"hey\" }}{{ true }}").unwrap();
     assert_eq!(ast[0], Node::VariableBlock(WS::default(), Expr::new(ExprVal::Int(2))));
     assert_eq!(ast[1], Node::VariableBlock(WS::default(), Expr::new(ExprVal::Float(3.14))));
-    assert_eq!(ast[2], Node::VariableBlock(WS::default(), Expr::new(ExprVal::String("hey".to_string()))),);
+    assert_eq!(
+        ast[2],
+        Node::VariableBlock(WS::default(), Expr::new(ExprVal::String("hey".to_string()))),
+    );
     assert_eq!(ast[3], Node::VariableBlock(WS::default(), Expr::new(ExprVal::Bool(true))));
 }
 
@@ -97,15 +112,18 @@ fn parse_variable_tag_lit_math_expression() {
 
     assert_eq!(
         ast[0],
-        Node::VariableBlock(WS::default(), Expr::new(ExprVal::Math(MathExpr {
-            lhs: Box::new(Expr::new(ExprVal::Ident("count".to_string()))),
-            operator: MathOperator::Add,
-            rhs: Box::new(Expr::new(ExprVal::Math(MathExpr {
-                lhs: Box::new(Expr::new(ExprVal::Int(1))),
-                operator: MathOperator::Mul,
-                rhs: Box::new(Expr::new(ExprVal::Float(2.5))),
-            },))),
-        },))),
+        Node::VariableBlock(
+            WS::default(),
+            Expr::new(ExprVal::Math(MathExpr {
+                lhs: Box::new(Expr::new(ExprVal::Ident("count".to_string()))),
+                operator: MathOperator::Add,
+                rhs: Box::new(Expr::new(ExprVal::Math(MathExpr {
+                    lhs: Box::new(Expr::new(ExprVal::Int(1))),
+                    operator: MathOperator::Mul,
+                    rhs: Box::new(Expr::new(ExprVal::Float(2.5))),
+                },))),
+            },))
+        ),
     );
 }
 
@@ -114,15 +132,18 @@ fn parse_variable_tag_lit_math_expression_with_parentheses() {
     let ast = parse("{{ (count + 1) * 2.5 }}").unwrap();
     assert_eq!(
         ast[0],
-        Node::VariableBlock(WS::default(), Expr::new(ExprVal::Math(MathExpr {
-            lhs: Box::new(Expr::new(ExprVal::Math(MathExpr {
-                lhs: Box::new(Expr::new(ExprVal::Ident("count".to_string()))),
-                operator: MathOperator::Add,
-                rhs: Box::new(Expr::new(ExprVal::Int(1))),
-            },))),
-            operator: MathOperator::Mul,
-            rhs: Box::new(Expr::new(ExprVal::Float(2.5))),
-        },)))
+        Node::VariableBlock(
+            WS::default(),
+            Expr::new(ExprVal::Math(MathExpr {
+                lhs: Box::new(Expr::new(ExprVal::Math(MathExpr {
+                    lhs: Box::new(Expr::new(ExprVal::Ident("count".to_string()))),
+                    operator: MathOperator::Add,
+                    rhs: Box::new(Expr::new(ExprVal::Int(1))),
+                },))),
+                operator: MathOperator::Mul,
+                rhs: Box::new(Expr::new(ExprVal::Float(2.5))),
+            },))
+        )
     );
 }
 
@@ -131,18 +152,21 @@ fn parse_variable_tag_lit_math_expression_with_parentheses_and_filter() {
     let ast = parse("{{ (count + 1) * 2.5 | round }}").unwrap();
     assert_eq!(
         ast[0],
-        Node::VariableBlock(WS::default(), Expr::with_filters(
-            ExprVal::Math(MathExpr {
-                lhs: Box::new(Expr::new(ExprVal::Math(MathExpr {
-                    lhs: Box::new(Expr::new(ExprVal::Ident("count".to_string()))),
-                    operator: MathOperator::Add,
-                    rhs: Box::new(Expr::new(ExprVal::Int(1))),
-                },))),
-                operator: MathOperator::Mul,
-                rhs: Box::new(Expr::new(ExprVal::Float(2.5))),
-            },),
-            vec![FunctionCall { name: "round".to_string(), args: HashMap::new() },],
-        ))
+        Node::VariableBlock(
+            WS::default(),
+            Expr::with_filters(
+                ExprVal::Math(MathExpr {
+                    lhs: Box::new(Expr::new(ExprVal::Math(MathExpr {
+                        lhs: Box::new(Expr::new(ExprVal::Ident("count".to_string()))),
+                        operator: MathOperator::Add,
+                        rhs: Box::new(Expr::new(ExprVal::Int(1))),
+                    },))),
+                    operator: MathOperator::Mul,
+                    rhs: Box::new(Expr::new(ExprVal::Float(2.5))),
+                },),
+                vec![FunctionCall { name: "round".to_string(), args: HashMap::new() },],
+            )
+        )
     );
 }
 
@@ -151,14 +175,17 @@ fn parse_variable_math_on_filter() {
     let ast = parse("{{ a | length - 1 }}").unwrap();
     assert_eq!(
         ast[0],
-        Node::VariableBlock(WS::default(), Expr::new(ExprVal::Math(MathExpr {
-            lhs: Box::new(Expr::with_filters(
-                ExprVal::Ident("a".to_string()),
-                vec![FunctionCall { name: "length".to_string(), args: HashMap::new() },],
-            )),
-            operator: MathOperator::Sub,
-            rhs: Box::new(Expr::new(ExprVal::Int(1))),
-        },)))
+        Node::VariableBlock(
+            WS::default(),
+            Expr::new(ExprVal::Math(MathExpr {
+                lhs: Box::new(Expr::with_filters(
+                    ExprVal::Ident("a".to_string()),
+                    vec![FunctionCall { name: "length".to_string(), args: HashMap::new() },],
+                )),
+                operator: MathOperator::Sub,
+                rhs: Box::new(Expr::new(ExprVal::Int(1))),
+            },))
+        )
     );
 }
 
@@ -167,11 +194,14 @@ fn parse_variable_tag_simple_logic_expression() {
     let ast = parse("{{ 1 > 2 }}").unwrap();
     assert_eq!(
         ast[0],
-        Node::VariableBlock(WS::default(), Expr::new(ExprVal::Logic(LogicExpr {
-            lhs: Box::new(Expr::new(ExprVal::Int(1))),
-            operator: LogicOperator::Gt,
-            rhs: Box::new(Expr::new(ExprVal::Int(2))),
-        },)))
+        Node::VariableBlock(
+            WS::default(),
+            Expr::new(ExprVal::Logic(LogicExpr {
+                lhs: Box::new(Expr::new(ExprVal::Int(1))),
+                operator: LogicOperator::Gt,
+                rhs: Box::new(Expr::new(ExprVal::Int(2))),
+            },))
+        )
     );
 }
 
@@ -180,19 +210,22 @@ fn parse_variable_tag_math_and_logic_expression() {
     let ast = parse("{{ count + 1 * 2.5 and admin }}").unwrap();
     assert_eq!(
         ast[0],
-        Node::VariableBlock(WS::default(), Expr::new(ExprVal::Logic(LogicExpr {
-            lhs: Box::new(Expr::new(ExprVal::Math(MathExpr {
-                lhs: Box::new(Expr::new(ExprVal::Ident("count".to_string()))),
-                operator: MathOperator::Add,
-                rhs: Box::new(Expr::new(ExprVal::Math(MathExpr {
-                    lhs: Box::new(Expr::new(ExprVal::Int(1))),
-                    operator: MathOperator::Mul,
-                    rhs: Box::new(Expr::new(ExprVal::Float(2.5))),
+        Node::VariableBlock(
+            WS::default(),
+            Expr::new(ExprVal::Logic(LogicExpr {
+                lhs: Box::new(Expr::new(ExprVal::Math(MathExpr {
+                    lhs: Box::new(Expr::new(ExprVal::Ident("count".to_string()))),
+                    operator: MathOperator::Add,
+                    rhs: Box::new(Expr::new(ExprVal::Math(MathExpr {
+                        lhs: Box::new(Expr::new(ExprVal::Int(1))),
+                        operator: MathOperator::Mul,
+                        rhs: Box::new(Expr::new(ExprVal::Float(2.5))),
+                    },))),
                 },))),
-            },))),
-            operator: LogicOperator::And,
-            rhs: Box::new(Expr::new(ExprVal::Ident("admin".to_string()))),
-        },)))
+                operator: LogicOperator::And,
+                rhs: Box::new(Expr::new(ExprVal::Ident("admin".to_string()))),
+            },))
+        )
     );
 }
 
@@ -201,29 +234,35 @@ fn parse_variable_tag_math_with_filters_and_logic_expression() {
     let ast = parse("{{ count + 1 * 2.5 | round and admin }}").unwrap();
     assert_eq!(
         ast[0],
-        Node::VariableBlock(WS::default(), Expr::new(ExprVal::Logic(LogicExpr {
-            lhs: Box::new(Expr::with_filters(
-                ExprVal::Math(MathExpr {
-                    lhs: Box::new(Expr::new(ExprVal::Ident("count".to_string()))),
-                    operator: MathOperator::Add,
-                    rhs: Box::new(Expr::new(ExprVal::Math(MathExpr {
-                        lhs: Box::new(Expr::new(ExprVal::Int(1))),
-                        operator: MathOperator::Mul,
-                        rhs: Box::new(Expr::new(ExprVal::Float(2.5))),
-                    },))),
-                },),
-                vec![FunctionCall { name: "round".to_string(), args: HashMap::new() },],
-            )),
-            operator: LogicOperator::And,
-            rhs: Box::new(Expr::new(ExprVal::Ident("admin".to_string()))),
-        },)))
+        Node::VariableBlock(
+            WS::default(),
+            Expr::new(ExprVal::Logic(LogicExpr {
+                lhs: Box::new(Expr::with_filters(
+                    ExprVal::Math(MathExpr {
+                        lhs: Box::new(Expr::new(ExprVal::Ident("count".to_string()))),
+                        operator: MathOperator::Add,
+                        rhs: Box::new(Expr::new(ExprVal::Math(MathExpr {
+                            lhs: Box::new(Expr::new(ExprVal::Int(1))),
+                            operator: MathOperator::Mul,
+                            rhs: Box::new(Expr::new(ExprVal::Float(2.5))),
+                        },))),
+                    },),
+                    vec![FunctionCall { name: "round".to_string(), args: HashMap::new() },],
+                )),
+                operator: LogicOperator::And,
+                rhs: Box::new(Expr::new(ExprVal::Ident("admin".to_string()))),
+            },))
+        )
     );
 }
 
 #[test]
 fn parse_variable_tag_simple_negated_expr() {
     let ast = parse("{{ not id }}").unwrap();
-    assert_eq!(ast[0], Node::VariableBlock(WS::default(), Expr::new_negated(ExprVal::Ident("id".to_string()))));
+    assert_eq!(
+        ast[0],
+        Node::VariableBlock(WS::default(), Expr::new_negated(ExprVal::Ident("id".to_string())))
+    );
 }
 
 #[test]
@@ -231,12 +270,15 @@ fn parse_test() {
     let ast = parse("{{ a is divisibleby(2) }}").unwrap();
     assert_eq!(
         ast[0],
-        Node::VariableBlock(WS::default(), Expr::new(ExprVal::Test(Test {
-            ident: "a".to_string(),
-            negated: false,
-            name: "divisibleby".to_string(),
-            args: vec![Expr::new(ExprVal::Int(2))]
-        })))
+        Node::VariableBlock(
+            WS::default(),
+            Expr::new(ExprVal::Test(Test {
+                ident: "a".to_string(),
+                negated: false,
+                name: "divisibleby".to_string(),
+                args: vec![Expr::new(ExprVal::Int(2))]
+            }))
+        )
     );
 }
 
@@ -245,19 +287,22 @@ fn parse_variable_tag_negated_expr() {
     let ast = parse("{{ not id and not true and not 1 + 1 }}").unwrap();
     assert_eq!(
         ast[0],
-        Node::VariableBlock(WS::default(), Expr::new(ExprVal::Logic(LogicExpr {
-            lhs: Box::new(Expr::new(ExprVal::Logic(LogicExpr {
-                lhs: Box::new(Expr::new_negated(ExprVal::Ident("id".to_string()))),
+        Node::VariableBlock(
+            WS::default(),
+            Expr::new(ExprVal::Logic(LogicExpr {
+                lhs: Box::new(Expr::new(ExprVal::Logic(LogicExpr {
+                    lhs: Box::new(Expr::new_negated(ExprVal::Ident("id".to_string()))),
+                    operator: LogicOperator::And,
+                    rhs: Box::new(Expr::new_negated(ExprVal::Bool(true))),
+                },))),
                 operator: LogicOperator::And,
-                rhs: Box::new(Expr::new_negated(ExprVal::Bool(true))),
-            },))),
-            operator: LogicOperator::And,
-            rhs: Box::new(Expr::new_negated(ExprVal::Math(MathExpr {
-                lhs: Box::new(Expr::new(ExprVal::Int(1))),
-                operator: MathOperator::Add,
-                rhs: Box::new(Expr::new(ExprVal::Int(1))),
-            },))),
-        },)))
+                rhs: Box::new(Expr::new_negated(ExprVal::Math(MathExpr {
+                    lhs: Box::new(Expr::new(ExprVal::Int(1))),
+                    operator: MathOperator::Add,
+                    rhs: Box::new(Expr::new(ExprVal::Int(1))),
+                },))),
+            },))
+        )
     );
 }
 
@@ -266,12 +311,15 @@ fn parse_variable_tag_simple_test() {
     let ast = parse("{{ id is defined }}").unwrap();
     assert_eq!(
         ast[0],
-        Node::VariableBlock(WS::default(), Expr::new(ExprVal::Test(Test {
-            ident: "id".to_string(),
-            negated: false,
-            name: "defined".to_string(),
-            args: vec![],
-        },)))
+        Node::VariableBlock(
+            WS::default(),
+            Expr::new(ExprVal::Test(Test {
+                ident: "id".to_string(),
+                negated: false,
+                name: "defined".to_string(),
+                args: vec![],
+            },))
+        )
     );
 }
 
@@ -280,12 +328,15 @@ fn parse_variable_tag_simple_negated_test() {
     let ast = parse("{{ id is not defined }}").unwrap();
     assert_eq!(
         ast[0],
-        Node::VariableBlock(WS::default(), Expr::new(ExprVal::Test(Test {
-            ident: "id".to_string(),
-            negated: true,
-            name: "defined".to_string(),
-            args: vec![],
-        },)))
+        Node::VariableBlock(
+            WS::default(),
+            Expr::new(ExprVal::Test(Test {
+                ident: "id".to_string(),
+                negated: true,
+                name: "defined".to_string(),
+                args: vec![],
+            },))
+        )
     );
 }
 
@@ -294,16 +345,19 @@ fn parse_variable_tag_test_as_expression() {
     let ast = parse("{{ user is defined and user.admin }}").unwrap();
     assert_eq!(
         ast[0],
-        Node::VariableBlock(WS::default(), Expr::new(ExprVal::Logic(LogicExpr {
-            lhs: Box::new(Expr::new(ExprVal::Test(Test {
-                ident: "user".to_string(),
-                negated: false,
-                name: "defined".to_string(),
-                args: vec![],
-            },))),
-            operator: LogicOperator::And,
-            rhs: Box::new(Expr::new(ExprVal::Ident("user.admin".to_string()))),
-        },)))
+        Node::VariableBlock(
+            WS::default(),
+            Expr::new(ExprVal::Logic(LogicExpr {
+                lhs: Box::new(Expr::new(ExprVal::Test(Test {
+                    ident: "user".to_string(),
+                    negated: false,
+                    name: "defined".to_string(),
+                    args: vec![],
+                },))),
+                operator: LogicOperator::And,
+                rhs: Box::new(Expr::new(ExprVal::Ident("user.admin".to_string()))),
+            },))
+        )
     );
 }
 
@@ -315,11 +369,14 @@ fn parse_variable_tag_macro_call() {
 
     assert_eq!(
         ast[0],
-        Node::VariableBlock(WS::default(), Expr::new(ExprVal::MacroCall(MacroCall {
-            namespace: "macros".to_string(),
-            name: "get_time".to_string(),
-            args,
-        },)))
+        Node::VariableBlock(
+            WS::default(),
+            Expr::new(ExprVal::MacroCall(MacroCall {
+                namespace: "macros".to_string(),
+                name: "get_time".to_string(),
+                args,
+            },))
+        )
     );
 }
 
@@ -335,11 +392,14 @@ fn parse_variable_tag_macro_call_with_array() {
 
     assert_eq!(
         ast[0],
-        Node::VariableBlock(WS::default(), Expr::new(ExprVal::MacroCall(MacroCall {
-            namespace: "macros".to_string(),
-            name: "get_time".to_string(),
-            args,
-        },)))
+        Node::VariableBlock(
+            WS::default(),
+            Expr::new(ExprVal::MacroCall(MacroCall {
+                namespace: "macros".to_string(),
+                name: "get_time".to_string(),
+                args,
+            },))
+        )
     );
 }
 #[test]
@@ -350,14 +410,17 @@ fn parse_variable_tag_macro_call_with_filter() {
 
     assert_eq!(
         ast[0],
-        Node::VariableBlock(WS::default(), Expr::with_filters(
-            ExprVal::MacroCall(MacroCall {
-                namespace: "macros".to_string(),
-                name: "get_time".to_string(),
-                args,
-            },),
-            vec![FunctionCall { name: "round".to_string(), args: HashMap::new() },],
-        ))
+        Node::VariableBlock(
+            WS::default(),
+            Expr::with_filters(
+                ExprVal::MacroCall(MacroCall {
+                    namespace: "macros".to_string(),
+                    name: "get_time".to_string(),
+                    args,
+                },),
+                vec![FunctionCall { name: "round".to_string(), args: HashMap::new() },],
+            )
+        )
     );
 }
 
@@ -369,10 +432,10 @@ fn parse_variable_tag_global_function() {
 
     assert_eq!(
         ast[0],
-        Node::VariableBlock(WS::default(), Expr::new(ExprVal::FunctionCall(FunctionCall {
-            name: "get_time".to_string(),
-            args,
-        },)))
+        Node::VariableBlock(
+            WS::default(),
+            Expr::new(ExprVal::FunctionCall(FunctionCall { name: "get_time".to_string(), args },))
+        )
     );
 }
 
@@ -384,11 +447,14 @@ fn parse_in_condition() {
 
     assert_eq!(
         ast[0],
-        Node::VariableBlock(WS::default(), Expr::new(ExprVal::In(In {
-            lhs: Box::new(Expr::new(ExprVal::Ident("b".to_string()))),
-            rhs: Box::new(Expr::new(ExprVal::Ident("c".to_string()))),
-            negated: false,
-        })))
+        Node::VariableBlock(
+            WS::default(),
+            Expr::new(ExprVal::In(In {
+                lhs: Box::new(Expr::new(ExprVal::Ident("b".to_string()))),
+                rhs: Box::new(Expr::new(ExprVal::Ident("c".to_string()))),
+                negated: false,
+            }))
+        )
     );
 }
 
@@ -400,11 +466,14 @@ fn parse_negated_in_condition() {
 
     assert_eq!(
         ast[0],
-        Node::VariableBlock(WS::default(), Expr::new(ExprVal::In(In {
-            lhs: Box::new(Expr::new(ExprVal::Ident("b".to_string()))),
-            rhs: Box::new(Expr::new(ExprVal::Ident("c".to_string()))),
-            negated: true,
-        })))
+        Node::VariableBlock(
+            WS::default(),
+            Expr::new(ExprVal::In(In {
+                lhs: Box::new(Expr::new(ExprVal::Ident("b".to_string()))),
+                rhs: Box::new(Expr::new(ExprVal::Ident("c".to_string()))),
+                negated: true,
+            }))
+        )
     );
 }
 
@@ -416,13 +485,16 @@ fn parse_variable_tag_global_function_with_filter() {
 
     assert_eq!(
         ast[0],
-        Node::VariableBlock(WS::default(), Expr::with_filters(
-            ExprVal::FunctionCall(FunctionCall { name: "get_time".to_string(), args },),
-            vec![
-                FunctionCall { name: "round".to_string(), args: HashMap::new() },
-                FunctionCall { name: "upper".to_string(), args: HashMap::new() },
-            ],
-        ))
+        Node::VariableBlock(
+            WS::default(),
+            Expr::with_filters(
+                ExprVal::FunctionCall(FunctionCall { name: "get_time".to_string(), args },),
+                vec![
+                    FunctionCall { name: "round".to_string(), args: HashMap::new() },
+                    FunctionCall { name: "upper".to_string(), args: HashMap::new() },
+                ],
+            )
+        )
     );
 }
 
@@ -813,16 +885,25 @@ fn parse_continue() {
 #[test]
 fn parse_string_concat_can_merge() {
     let ast = parse("{{ `hello` ~ 'hey' }}").unwrap();
-    assert_eq!(ast[0], Node::VariableBlock(WS::default(), Expr::new(ExprVal::String("hellohey".to_string()))),);
+    assert_eq!(
+        ast[0],
+        Node::VariableBlock(WS::default(), Expr::new(ExprVal::String("hellohey".to_string()))),
+    );
 }
 #[test]
 fn parse_string_concat() {
     let ast = parse("{{ `hello` ~ ident }}").unwrap();
     assert_eq!(
         ast[0],
-        Node::VariableBlock(WS::default(), Expr::new(ExprVal::StringConcat(StringConcat {
-            values: vec![ExprVal::String("hello".to_string()), ExprVal::Ident("ident".to_string()),]
-        }))),
+        Node::VariableBlock(
+            WS::default(),
+            Expr::new(ExprVal::StringConcat(StringConcat {
+                values: vec![
+                    ExprVal::String("hello".to_string()),
+                    ExprVal::Ident("ident".to_string()),
+                ]
+            }))
+        ),
     );
 }
 
@@ -831,12 +912,15 @@ fn parse_string_concat_multiple() {
     let ast = parse("{{ `hello` ~ ident ~ 'ho' }}").unwrap();
     assert_eq!(
         ast[0],
-        Node::VariableBlock(WS::default(), Expr::new(ExprVal::StringConcat(StringConcat {
-            values: vec![
-                ExprVal::String("hello".to_string()),
-                ExprVal::Ident("ident".to_string()),
-                ExprVal::String("ho".to_string()),
-            ]
-        }))),
+        Node::VariableBlock(
+            WS::default(),
+            Expr::new(ExprVal::StringConcat(StringConcat {
+                values: vec![
+                    ExprVal::String("hello".to_string()),
+                    ExprVal::Ident("ident".to_string()),
+                    ExprVal::String("ho".to_string()),
+                ]
+            }))
+        ),
     );
 }

--- a/src/parser/tests/parser.rs
+++ b/src/parser/tests/parser.rs
@@ -55,7 +55,7 @@ fn parse_import_macro() {
 #[test]
 fn parse_variable_tag_ident() {
     let ast = parse("{{ id }}").unwrap();
-    assert_eq!(ast[0], Node::VariableBlock(Expr::new(ExprVal::Ident("id".to_string()))),);
+    assert_eq!(ast[0], Node::VariableBlock(WS::default(), Expr::new(ExprVal::Ident("id".to_string()))),);
 }
 
 #[test]
@@ -66,7 +66,7 @@ fn parse_variable_tag_ident_with_simple_filters() {
 
     assert_eq!(
         ast[0],
-        Node::VariableBlock(Expr::with_filters(
+        Node::VariableBlock(WS::default(), Expr::with_filters(
             ExprVal::Ident("arr".to_string()),
             vec![
                 FunctionCall { name: "first".to_string(), args: HashMap::new() },
@@ -79,10 +79,10 @@ fn parse_variable_tag_ident_with_simple_filters() {
 #[test]
 fn parse_variable_tag_lit() {
     let ast = parse("{{ 2 }}{{ 3.14 }}{{ \"hey\" }}{{ true }}").unwrap();
-    assert_eq!(ast[0], Node::VariableBlock(Expr::new(ExprVal::Int(2))));
-    assert_eq!(ast[1], Node::VariableBlock(Expr::new(ExprVal::Float(3.14))));
-    assert_eq!(ast[2], Node::VariableBlock(Expr::new(ExprVal::String("hey".to_string()))),);
-    assert_eq!(ast[3], Node::VariableBlock(Expr::new(ExprVal::Bool(true))));
+    assert_eq!(ast[0], Node::VariableBlock(WS::default(), Expr::new(ExprVal::Int(2))));
+    assert_eq!(ast[1], Node::VariableBlock(WS::default(), Expr::new(ExprVal::Float(3.14))));
+    assert_eq!(ast[2], Node::VariableBlock(WS::default(), Expr::new(ExprVal::String("hey".to_string()))),);
+    assert_eq!(ast[3], Node::VariableBlock(WS::default(), Expr::new(ExprVal::Bool(true))));
 }
 
 #[test]
@@ -91,7 +91,7 @@ fn parse_variable_tag_lit_math_expression() {
 
     assert_eq!(
         ast[0],
-        Node::VariableBlock(Expr::new(ExprVal::Math(MathExpr {
+        Node::VariableBlock(WS::default(), Expr::new(ExprVal::Math(MathExpr {
             lhs: Box::new(Expr::new(ExprVal::Ident("count".to_string()))),
             operator: MathOperator::Add,
             rhs: Box::new(Expr::new(ExprVal::Math(MathExpr {
@@ -108,7 +108,7 @@ fn parse_variable_tag_lit_math_expression_with_parentheses() {
     let ast = parse("{{ (count + 1) * 2.5 }}").unwrap();
     assert_eq!(
         ast[0],
-        Node::VariableBlock(Expr::new(ExprVal::Math(MathExpr {
+        Node::VariableBlock(WS::default(), Expr::new(ExprVal::Math(MathExpr {
             lhs: Box::new(Expr::new(ExprVal::Math(MathExpr {
                 lhs: Box::new(Expr::new(ExprVal::Ident("count".to_string()))),
                 operator: MathOperator::Add,
@@ -125,7 +125,7 @@ fn parse_variable_tag_lit_math_expression_with_parentheses_and_filter() {
     let ast = parse("{{ (count + 1) * 2.5 | round }}").unwrap();
     assert_eq!(
         ast[0],
-        Node::VariableBlock(Expr::with_filters(
+        Node::VariableBlock(WS::default(), Expr::with_filters(
             ExprVal::Math(MathExpr {
                 lhs: Box::new(Expr::new(ExprVal::Math(MathExpr {
                     lhs: Box::new(Expr::new(ExprVal::Ident("count".to_string()))),
@@ -145,7 +145,7 @@ fn parse_variable_math_on_filter() {
     let ast = parse("{{ a | length - 1 }}").unwrap();
     assert_eq!(
         ast[0],
-        Node::VariableBlock(Expr::new(ExprVal::Math(MathExpr {
+        Node::VariableBlock(WS::default(), Expr::new(ExprVal::Math(MathExpr {
             lhs: Box::new(Expr::with_filters(
                 ExprVal::Ident("a".to_string()),
                 vec![FunctionCall { name: "length".to_string(), args: HashMap::new() },],
@@ -161,7 +161,7 @@ fn parse_variable_tag_simple_logic_expression() {
     let ast = parse("{{ 1 > 2 }}").unwrap();
     assert_eq!(
         ast[0],
-        Node::VariableBlock(Expr::new(ExprVal::Logic(LogicExpr {
+        Node::VariableBlock(WS::default(), Expr::new(ExprVal::Logic(LogicExpr {
             lhs: Box::new(Expr::new(ExprVal::Int(1))),
             operator: LogicOperator::Gt,
             rhs: Box::new(Expr::new(ExprVal::Int(2))),
@@ -174,7 +174,7 @@ fn parse_variable_tag_math_and_logic_expression() {
     let ast = parse("{{ count + 1 * 2.5 and admin }}").unwrap();
     assert_eq!(
         ast[0],
-        Node::VariableBlock(Expr::new(ExprVal::Logic(LogicExpr {
+        Node::VariableBlock(WS::default(), Expr::new(ExprVal::Logic(LogicExpr {
             lhs: Box::new(Expr::new(ExprVal::Math(MathExpr {
                 lhs: Box::new(Expr::new(ExprVal::Ident("count".to_string()))),
                 operator: MathOperator::Add,
@@ -195,7 +195,7 @@ fn parse_variable_tag_math_with_filters_and_logic_expression() {
     let ast = parse("{{ count + 1 * 2.5 | round and admin }}").unwrap();
     assert_eq!(
         ast[0],
-        Node::VariableBlock(Expr::new(ExprVal::Logic(LogicExpr {
+        Node::VariableBlock(WS::default(), Expr::new(ExprVal::Logic(LogicExpr {
             lhs: Box::new(Expr::with_filters(
                 ExprVal::Math(MathExpr {
                     lhs: Box::new(Expr::new(ExprVal::Ident("count".to_string()))),
@@ -217,7 +217,7 @@ fn parse_variable_tag_math_with_filters_and_logic_expression() {
 #[test]
 fn parse_variable_tag_simple_negated_expr() {
     let ast = parse("{{ not id }}").unwrap();
-    assert_eq!(ast[0], Node::VariableBlock(Expr::new_negated(ExprVal::Ident("id".to_string()))));
+    assert_eq!(ast[0], Node::VariableBlock(WS::default(), Expr::new_negated(ExprVal::Ident("id".to_string()))));
 }
 
 #[test]
@@ -225,7 +225,7 @@ fn parse_test() {
     let ast = parse("{{ a is divisibleby(2) }}").unwrap();
     assert_eq!(
         ast[0],
-        Node::VariableBlock(Expr::new(ExprVal::Test(Test {
+        Node::VariableBlock(WS::default(), Expr::new(ExprVal::Test(Test {
             ident: "a".to_string(),
             negated: false,
             name: "divisibleby".to_string(),
@@ -239,7 +239,7 @@ fn parse_variable_tag_negated_expr() {
     let ast = parse("{{ not id and not true and not 1 + 1 }}").unwrap();
     assert_eq!(
         ast[0],
-        Node::VariableBlock(Expr::new(ExprVal::Logic(LogicExpr {
+        Node::VariableBlock(WS::default(), Expr::new(ExprVal::Logic(LogicExpr {
             lhs: Box::new(Expr::new(ExprVal::Logic(LogicExpr {
                 lhs: Box::new(Expr::new_negated(ExprVal::Ident("id".to_string()))),
                 operator: LogicOperator::And,
@@ -260,7 +260,7 @@ fn parse_variable_tag_simple_test() {
     let ast = parse("{{ id is defined }}").unwrap();
     assert_eq!(
         ast[0],
-        Node::VariableBlock(Expr::new(ExprVal::Test(Test {
+        Node::VariableBlock(WS::default(), Expr::new(ExprVal::Test(Test {
             ident: "id".to_string(),
             negated: false,
             name: "defined".to_string(),
@@ -274,7 +274,7 @@ fn parse_variable_tag_simple_negated_test() {
     let ast = parse("{{ id is not defined }}").unwrap();
     assert_eq!(
         ast[0],
-        Node::VariableBlock(Expr::new(ExprVal::Test(Test {
+        Node::VariableBlock(WS::default(), Expr::new(ExprVal::Test(Test {
             ident: "id".to_string(),
             negated: true,
             name: "defined".to_string(),
@@ -288,7 +288,7 @@ fn parse_variable_tag_test_as_expression() {
     let ast = parse("{{ user is defined and user.admin }}").unwrap();
     assert_eq!(
         ast[0],
-        Node::VariableBlock(Expr::new(ExprVal::Logic(LogicExpr {
+        Node::VariableBlock(WS::default(), Expr::new(ExprVal::Logic(LogicExpr {
             lhs: Box::new(Expr::new(ExprVal::Test(Test {
                 ident: "user".to_string(),
                 negated: false,
@@ -309,7 +309,7 @@ fn parse_variable_tag_macro_call() {
 
     assert_eq!(
         ast[0],
-        Node::VariableBlock(Expr::new(ExprVal::MacroCall(MacroCall {
+        Node::VariableBlock(WS::default(), Expr::new(ExprVal::MacroCall(MacroCall {
             namespace: "macros".to_string(),
             name: "get_time".to_string(),
             args,
@@ -329,7 +329,7 @@ fn parse_variable_tag_macro_call_with_array() {
 
     assert_eq!(
         ast[0],
-        Node::VariableBlock(Expr::new(ExprVal::MacroCall(MacroCall {
+        Node::VariableBlock(WS::default(), Expr::new(ExprVal::MacroCall(MacroCall {
             namespace: "macros".to_string(),
             name: "get_time".to_string(),
             args,
@@ -344,7 +344,7 @@ fn parse_variable_tag_macro_call_with_filter() {
 
     assert_eq!(
         ast[0],
-        Node::VariableBlock(Expr::with_filters(
+        Node::VariableBlock(WS::default(), Expr::with_filters(
             ExprVal::MacroCall(MacroCall {
                 namespace: "macros".to_string(),
                 name: "get_time".to_string(),
@@ -363,7 +363,7 @@ fn parse_variable_tag_global_function() {
 
     assert_eq!(
         ast[0],
-        Node::VariableBlock(Expr::new(ExprVal::FunctionCall(FunctionCall {
+        Node::VariableBlock(WS::default(), Expr::new(ExprVal::FunctionCall(FunctionCall {
             name: "get_time".to_string(),
             args,
         },)))
@@ -378,7 +378,7 @@ fn parse_in_condition() {
 
     assert_eq!(
         ast[0],
-        Node::VariableBlock(Expr::new(ExprVal::In(In {
+        Node::VariableBlock(WS::default(), Expr::new(ExprVal::In(In {
             lhs: Box::new(Expr::new(ExprVal::Ident("b".to_string()))),
             rhs: Box::new(Expr::new(ExprVal::Ident("c".to_string()))),
             negated: false,
@@ -394,7 +394,7 @@ fn parse_negated_in_condition() {
 
     assert_eq!(
         ast[0],
-        Node::VariableBlock(Expr::new(ExprVal::In(In {
+        Node::VariableBlock(WS::default(), Expr::new(ExprVal::In(In {
             lhs: Box::new(Expr::new(ExprVal::Ident("b".to_string()))),
             rhs: Box::new(Expr::new(ExprVal::Ident("c".to_string()))),
             negated: true,
@@ -410,7 +410,7 @@ fn parse_variable_tag_global_function_with_filter() {
 
     assert_eq!(
         ast[0],
-        Node::VariableBlock(Expr::with_filters(
+        Node::VariableBlock(WS::default(), Expr::with_filters(
             ExprVal::FunctionCall(FunctionCall { name: "get_time".to_string(), args },),
             vec![
                 FunctionCall { name: "round".to_string(), args: HashMap::new() },
@@ -612,7 +612,7 @@ fn parse_simple_macro_definition() {
                 args,
                 body: vec![
                     Node::Text("A: ".to_string()),
-                    Node::VariableBlock(Expr::new(ExprVal::Ident("a".to_string()))),
+                    Node::VariableBlock(WS::default(), Expr::new(ExprVal::Ident("a".to_string()))),
                 ],
             },
             WS::default(),
@@ -807,14 +807,14 @@ fn parse_continue() {
 #[test]
 fn parse_string_concat_can_merge() {
     let ast = parse("{{ `hello` ~ 'hey' }}").unwrap();
-    assert_eq!(ast[0], Node::VariableBlock(Expr::new(ExprVal::String("hellohey".to_string()))),);
+    assert_eq!(ast[0], Node::VariableBlock(WS::default(), Expr::new(ExprVal::String("hellohey".to_string()))),);
 }
 #[test]
 fn parse_string_concat() {
     let ast = parse("{{ `hello` ~ ident }}").unwrap();
     assert_eq!(
         ast[0],
-        Node::VariableBlock(Expr::new(ExprVal::StringConcat(StringConcat {
+        Node::VariableBlock(WS::default(), Expr::new(ExprVal::StringConcat(StringConcat {
             values: vec![ExprVal::String("hello".to_string()), ExprVal::Ident("ident".to_string()),]
         }))),
     );
@@ -825,7 +825,7 @@ fn parse_string_concat_multiple() {
     let ast = parse("{{ `hello` ~ ident ~ 'ho' }}").unwrap();
     assert_eq!(
         ast[0],
-        Node::VariableBlock(Expr::new(ExprVal::StringConcat(StringConcat {
+        Node::VariableBlock(WS::default(), Expr::new(ExprVal::StringConcat(StringConcat {
             values: vec![
                 ExprVal::String("hello".to_string()),
                 ExprVal::Ident("ident".to_string()),

--- a/src/parser/tests/parser.rs
+++ b/src/parser/tests/parser.rs
@@ -53,6 +53,12 @@ fn parse_import_macro() {
 }
 
 #[test]
+fn parse_variable_with_whitespace_trimming() {
+    let ast = parse("{{- id }}").unwrap();
+    assert_eq!(ast[0], Node::VariableBlock(WS { left: true, right: false }, Expr::new(ExprVal::Ident("id".to_string()))),);
+}
+
+#[test]
 fn parse_variable_tag_ident() {
     let ast = parse("{{ id }}").unwrap();
     assert_eq!(ast[0], Node::VariableBlock(WS::default(), Expr::new(ExprVal::Ident("id".to_string()))),);

--- a/src/parser/whitespace.rs
+++ b/src/parser/whitespace.rs
@@ -53,7 +53,8 @@ pub fn remove_whitespace(nodes: Vec<Node>, body_ws: Option<WS>) -> Vec<Node> {
                 // empty text nodes will be skipped
                 continue;
             }
-            Node::ImportMacro(ws, _, _)
+            Node::VariableBlock(ws, _)
+            | Node::ImportMacro(ws, _, _)
             | Node::Extends(ws, _)
             | Node::Include(ws, _)
             | Node::Set(ws, _)
@@ -170,7 +171,7 @@ pub fn remove_whitespace(nodes: Vec<Node>, body_ws: Option<WS>) -> Vec<Node> {
                 res.push(Node::If(If { conditions: new_conditions, otherwise }, end_ws));
                 continue;
             }
-            Node::Super | Node::VariableBlock(_) => (),
+            Node::Super => (),
         };
 
         // If we are there, that means it's not a text node and we didn't have to modify the node

--- a/src/renderer/processor.rs
+++ b/src/renderer/processor.rs
@@ -595,7 +595,10 @@ impl<'a> Processor<'a> {
                 }
             }
             ExprVal::Ident(_) => {
-                let mut res = self.eval_expression(&bool_expr).unwrap_or_else(|_| Cow::Owned(Value::Bool(false))).is_truthy();
+                let mut res = self
+                    .eval_expression(&bool_expr)
+                    .unwrap_or_else(|_| Cow::Owned(Value::Bool(false)))
+                    .is_truthy();
                 if bool_expr.negated {
                     res = !res;
                 }
@@ -905,7 +908,9 @@ impl<'a> Processor<'a> {
     fn render_node(&mut self, node: &'a Node, buffer: &mut String) -> Result<()> {
         match *node {
             Node::Text(ref s) | Node::Raw(_, ref s, _) => buffer.push_str(s),
-            Node::VariableBlock(_, ref expr) => buffer.push_str(&self.eval_expression(expr)?.render()),
+            Node::VariableBlock(_, ref expr) => {
+                buffer.push_str(&self.eval_expression(expr)?.render())
+            }
             Node::Set(_, ref set) => self.eval_set(set)?,
             Node::FilterSection(_, FilterSection { ref filter, ref body }, _) => {
                 let body = self.render_body(body)?;

--- a/src/renderer/processor.rs
+++ b/src/renderer/processor.rs
@@ -905,7 +905,7 @@ impl<'a> Processor<'a> {
     fn render_node(&mut self, node: &'a Node, buffer: &mut String) -> Result<()> {
         match *node {
             Node::Text(ref s) | Node::Raw(_, ref s, _) => buffer.push_str(s),
-            Node::VariableBlock(ref expr) => buffer.push_str(&self.eval_expression(expr)?.render()),
+            Node::VariableBlock(_, ref expr) => buffer.push_str(&self.eval_expression(expr)?.render()),
             Node::Set(_, ref set) => self.eval_set(set)?,
             Node::FilterSection(_, FilterSection { ref filter, ref body }, _) => {
                 let body = self.render_body(body)?;

--- a/src/renderer/tests/basic.rs
+++ b/src/renderer/tests/basic.rs
@@ -504,7 +504,7 @@ fn render_for() {
         (
             "{% for a in undefined_variable | default(value=[]) %}{{a}}{% else %}hello{% endfor %}",
             "hello"
-        ),        
+        ),
         (
             "{% for a in [] %}{{a}}{% else %}{% if 1 == 2 %}A{% else %}B{% endif %}{% endfor %}",
             "B"
@@ -849,7 +849,8 @@ fn split_on_context_value() {
 #[test]
 fn default_filter_works_in_condition() {
     let mut tera = Tera::default();
-    tera.add_raw_template("test.html", r#"{% if frobnicate|default(value=True) %}here{% endif %}"#).unwrap();
+    tera.add_raw_template("test.html", r#"{% if frobnicate|default(value=True) %}here{% endif %}"#)
+        .unwrap();
     let res = tera.render("test.html", Context::new());
     assert_eq!(res.unwrap(), "here");
 }

--- a/src/renderer/tests/whitespace.rs
+++ b/src/renderer/tests/whitespace.rs
@@ -19,6 +19,9 @@ fn can_remove_whitespace_basic() {
         ("  {% set var = 2 -%} {{var}}", "  2"),
         ("  {% raw -%}{{2}} {% endraw -%} ", "  {{2}}"),
         ("  {% filter upper -%} hey {%- endfilter -%} ", "  HEY"),
+        ("  {{ \"hello\" -}} ", "  hello"),
+        ("  {{- \"hello\" }} ", "hello "),
+        ("  {{- \"hello\" -}} ", "hello"),
     ];
 
     for (input, expected) in inputs {


### PR DESCRIPTION
Adds alternate start and end tokens for expressions (`{{-` and `-}}`) that allow the user to remove whitespace around expressions.

Closes #429 