### PR TITLE
fix: escape slash in JSON path according to RFC6901

### DIFF
--- a/src/renderer/processor.rs
+++ b/src/renderer/processor.rs
@@ -59,6 +59,7 @@ fn evaluate_sub_variables<'a>(key: &str, call_stack: &CallStack<'a>) -> Result<S
     }
 
     Ok(new_key
+        .replace("/", "~1") // https://tools.ietf.org/html/rfc6901#section-3
         .replace("['", ".")
         .replace("[\"", ".")
         .replace("[", ".")
@@ -595,7 +596,10 @@ impl<'a> Processor<'a> {
                 }
             }
             ExprVal::Ident(_) => {
-                let mut res = self.eval_expression(&bool_expr).unwrap_or_else(|_| Cow::Owned(Value::Bool(false))).is_truthy();
+                let mut res = self
+                    .eval_expression(&bool_expr)
+                    .unwrap_or_else(|_| Cow::Owned(Value::Bool(false)))
+                    .is_truthy();
                 if bool_expr.negated {
                     res = !res;
                 }

--- a/src/renderer/tests/square_brackets.rs
+++ b/src/renderer/tests/square_brackets.rs
@@ -23,8 +23,11 @@ fn var_access_by_square_brackets() {
     let mut map = HashMap::new();
     map.insert("true", "yes");
     map.insert("false", "no");
+    map.insert("with space", "works");
+    map.insert("with/slash", "works");
     let mut deep_map = HashMap::new();
     deep_map.insert("inner_map", &map);
+    context.insert("map", &map);
     context.insert("deep_map", &deep_map);
     context.insert("bool_vec", &vec!["true", "false"]);
 
@@ -35,6 +38,8 @@ fn var_access_by_square_brackets() {
         ("{{var['c'][0]}}", "fred"),
         ("{{var['c'][zero]}}", "fred"),
         ("{{var[a]}}", "i_am_actually_b"),
+        ("{{map['with space']}}", "works"),
+        ("{{map['with/slash']}}", "works"),
         ("{{deep_map['inner_map'][bool_vec[zero]]}}", "yes"),
     ];
 


### PR DESCRIPTION
see: https://tools.ietf.org/html/rfc6901#section-3

closes #431.