### PR TITLE
indent filter implementation

### DIFF
--- a/docs/content/docs/_index.md
+++ b/docs/content/docs/_index.md
@@ -778,6 +778,9 @@ By default, the filter will add an ellipsis at the end if the text was truncated
 change the string appended by setting the `end` argument.
 For example, `{{ value | truncate(length=10, end="") }}` will not append anything.
 
+#### indent
+Indents a string by injecting whitespace at the start of each line.  The `width` argument (default 4) specifies the number of spaces to insert per line.  If the `first` argument (default false) is set true spaces are inserted for the first line.  If the `blank` argument (default false) is set true spaces are inserted for blank/whitespace lines.
+
 #### striptags
 Tries to remove HTML tags from input. Does not guarantee well formed output if input is not valid HTML.
 

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -486,6 +486,7 @@ impl Tera {
         self.register_filter("trim", string::trim);
         #[cfg(feature = "builtins")]
         self.register_filter("truncate", string::truncate);
+        self.register_filter("indent", string::indent);
         self.register_filter("wordcount", string::wordcount);
         self.register_filter("replace", string::replace);
         self.register_filter("capitalize", string::capitalize);


### PR DESCRIPTION
This change implements the [indent](https://jinja.palletsprojects.com/en/2.10.x/templates/#indent) filter.  Unfortunately I couldn't find a good way to preserve the input line ending, but maybe that's less important these days.