### PR TITLE
Add support for specifying timezones for `date` filter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ percent-encoding = {version = "2", optional = true}
 humansize = {version = "1", optional = true}
 # used in date format filter
 chrono = {version = "0.4", optional = true}
+chrono-tz = {version = "0.5", optional = true}
 # used in truncate filter
 unic-segment = {version = "0.9", optional = true}
 
@@ -39,5 +40,5 @@ tempfile = "3"
 
 [features]
 default = ["builtins"]
-builtins = ["slug", "percent-encoding", "humansize", "chrono", "unic-segment"]
+builtins = ["slug", "percent-encoding", "humansize", "chrono", "chrono-tz", "unic-segment"]
 preserve_order = ["serde_json/preserve_order"]

--- a/docs/content/docs/_index.md
+++ b/docs/content/docs/_index.md
@@ -1052,6 +1052,16 @@ on [chrono docs](https://lifthrasiir.github.io/rust-chrono/chrono/format/strftim
 
 Example: `{{ ts | date }} {{ ts | date(format="%Y-%m-%d %H:%M") }}`
 
+If you are using ISO 8601 date strings you can optionally supply a timezone for the date to be rendered in:
+
+Example:
+
+```
+{{ "2019-09-19T13:18:48.731Z" | date(timezone="America/New_York") }}
+
+{{ "2019-09-19T13:18:48.731Z" | date(format="%Y-%m-%d %H:%M", timezone="Asia/Shanghai") }}
+```
+
 #### escape
 Escapes a string's HTML. Specifically, it makes these replacements:
 

--- a/docs/content/docs/_index.md
+++ b/docs/content/docs/_index.md
@@ -1052,7 +1052,7 @@ on [chrono docs](https://lifthrasiir.github.io/rust-chrono/chrono/format/strftim
 
 Example: `{{ ts | date }} {{ ts | date(format="%Y-%m-%d %H:%M") }}`
 
-If you are using ISO 8601 date strings you can optionally supply a timezone for the date to be rendered in:
+If you are using ISO 8601 date strings you can optionally supply a timezone for the date to be rendered in.
 
 Example:
 

--- a/src/builtins/filters/common.rs
+++ b/src/builtins/filters/common.rs
@@ -5,6 +5,7 @@ use std::iter::FromIterator;
 use crate::errors::{Error, Result};
 #[cfg(feature = "builtins")]
 use chrono::{DateTime, FixedOffset, NaiveDate, NaiveDateTime, Utc};
+#[cfg(feature = "builtins")]
 use chrono_tz::Tz;
 use serde_json::value::{to_value, Value};
 use serde_json::{to_string, to_string_pretty};

--- a/src/builtins/filters/common.rs
+++ b/src/builtins/filters/common.rs
@@ -5,6 +5,7 @@ use std::iter::FromIterator;
 use crate::errors::{Error, Result};
 #[cfg(feature = "builtins")]
 use chrono::{DateTime, FixedOffset, NaiveDate, NaiveDateTime, Utc};
+use chrono_tz::Tz;
 use serde_json::value::{to_value, Value};
 use serde_json::{to_string, to_string_pretty};
 
@@ -64,6 +65,19 @@ pub fn date(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
         None => "%Y-%m-%d".to_string(),
     };
 
+    let timezone = match args.get("timezone") {
+        Some(val) => {
+            let timezone = try_get_value!("date", "timezone", String, val);
+            match timezone.parse::<Tz>() {
+                Ok(timezone) => Some(timezone),
+                Err(_) => {
+                    return Err(Error::msg(format!("Error parsing `{}` as a timezone", timezone)))
+                }
+            }
+        }
+        None => None,
+    };
+
     let formatted = match value {
         Value::Number(n) => match n.as_i64() {
             Some(i) => NaiveDateTime::from_timestamp(i, 0).format(&format),
@@ -72,7 +86,10 @@ pub fn date(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
         Value::String(s) => {
             if s.contains('T') {
                 match s.parse::<DateTime<FixedOffset>>() {
-                    Ok(val) => val.format(&format),
+                    Ok(val) => match timezone {
+                        Some(timezone) => val.with_timezone(&timezone).format(&format),
+                        None => val.format(&format),
+                    },
                     Err(_) => match s.parse::<NaiveDateTime>() {
                         Ok(val) => val.format(&format),
                         Err(_) => {
@@ -246,6 +263,26 @@ mod tests {
         println!("{:?}", result);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), to_value("Sun, 05 Mar 2017 00:00:00").unwrap());
+    }
+
+    #[cfg(feature = "builtins")]
+    #[test]
+    fn date_with_timezone() {
+        let mut args = HashMap::new();
+        args.insert("timezone".to_string(), to_value("America/New_York").unwrap());
+        let result = date(&to_value("2019-09-19T01:48:44.581Z").unwrap(), &args);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), to_value("2019-09-18").unwrap());
+    }
+
+    #[cfg(feature = "builtins")]
+    #[test]
+    fn date_with_invalid_timezone() {
+        let mut args = HashMap::new();
+        args.insert("timezone".to_string(), to_value("Narnia").unwrap());
+        let result = date(&to_value("2019-09-19T01:48:44.581Z").unwrap(), &args);
+        assert!(result.is_err());
+        assert_eq!(result.err().unwrap().to_string(), "Error parsing `Narnia` as a timezone");
     }
 
     #[test]


### PR DESCRIPTION
This PR adds support for specifying a timezone in [IANA](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) format (e.g., `America/New_York`, `Asia/Shanghai`) when using the `date` filter.

Resolves #157.

### Motivation

When working on my Zola blog I noticed that when using UTC timestamps (generated with [`toISOString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString)) the dates were always rendered as UTC time rather than local time.

### Usage

```handlebars
<!-- Outputs "2019-09-18" -->
{{ "2019-09-19T01:48:44.581Z" | date(timezone="America/New_York" }}
```

### Questions

- Currently this is only implemented for RFC3339 dates. Do we want to support this for i64 timestamps as well? I don't think `YYYY-MM-DD` dates apply since they don't have a time component.

- This might pertain to Zola rather than Tera, but should we add a configuration option for a default timezone to use?