### PR TITLE
Avoid panic on dividing by 0

### DIFF
--- a/src/renderer/processor.rs
+++ b/src/renderer/processor.rs
@@ -611,7 +611,7 @@ impl<'a> Processor<'a> {
                         let ll = l.as_f64().unwrap();
                         let rr = r.as_f64().unwrap();
                         let res = ll / rr;
-                        if res.is_nan() {
+                        if res.is_nan() || res.is_infinite() {
                             None
                         } else {
                             Some(Number::from_f64(res).unwrap())


### PR DESCRIPTION
Dividing by 0 gives a panic because it leads to an unwrap().

Dividing by zero gives an infinite value. This patch adds a check for that.