### PR TITLE
Small doc fixes

### DIFF
--- a/docs/content/docs/_index.md
+++ b/docs/content/docs/_index.md
@@ -919,13 +919,13 @@ struct Post {
 The `attribute` argument can be used to group posts by year:
 
 ```jinja2
-{{ posts | sort(attribute="year") }}
+{{ posts | group_by(attribute="year") }}
 ```
 
 or by author name:
 
 ```jinja2
-{{ posts | sort(attribute="author.name") }}
+{{ posts | group_by(attribute="author.name") }}
 ```
 
 #### filter


### PR DESCRIPTION
Examples for the `group_by` filter were using `sort`.