### PR TITLE
PoC: Render can take &Context

### DIFF
--- a/benches/big_context.rs
+++ b/benches/big_context.rs
@@ -73,9 +73,9 @@ fn bench_big_loop_big_object(b: &mut test::Bencher) {
     .unwrap();
     let mut context = Context::new();
     context.insert("objects", &objects);
-    let rendering = tera.render("big_loop.html", context.clone()).expect("Good render");
+    let rendering = tera.render("big_loop.html", &context).expect("Good render");
     assert_eq!(&rendering[..], "0123");
-    b.iter(|| tera.render("big_loop.html", context.clone()));
+    b.iter(|| tera.render("big_loop.html", &context));
 }
 
 #[bench]
@@ -95,10 +95,10 @@ fn bench_macro_big_object(b: &mut test::Bencher) {
     let mut context = Context::new();
     context.insert("big_object", &big_object);
     context.insert("iterations", &(0..500).collect::<Vec<usize>>());
-    let rendering = tera.render("big_loop.html", context.clone()).expect("Good render");
+    let rendering = tera.render("big_loop.html", &context).expect("Good render");
     assert_eq!(rendering.len(), 500);
     assert_eq!(rendering.chars().next().expect("Char"), '1');
-    b.iter(|| tera.render("big_loop.html", context.clone()));
+    b.iter(|| tera.render("big_loop.html", &context));
 }
 
 #[bench]
@@ -116,9 +116,9 @@ fn bench_macro_big_object_no_loop_with_set(b: &mut test::Bencher) {
     .unwrap();
     let mut context = Context::new();
     context.insert("two_fields", &TwoFields::new());
-    let rendering = tera.render("no_loop.html", context.clone()).expect("Good render");
+    let rendering = tera.render("no_loop.html", &context).expect("Good render");
     assert_eq!(&rendering[..], "\nA\nB\nC\n");
-    b.iter(|| tera.render("no_loop.html", context.clone()));
+    b.iter(|| tera.render("no_loop.html", &context));
 }
 
 #[bench]
@@ -142,9 +142,9 @@ fn bench_macro_big_object_no_loop_macro_call(b: &mut test::Bencher) {
     .unwrap();
     let mut context = Context::new();
     context.insert("two_fields", &TwoFields::new());
-    let rendering = tera.render("no_loop.html", context.clone()).expect("Good render");
+    let rendering = tera.render("no_loop.html", &context).expect("Good render");
     assert_eq!(&rendering[..], "A");
-    b.iter(|| tera.render("no_loop.html", context.clone()));
+    b.iter(|| tera.render("no_loop.html", &context));
 }
 
 #[derive(Serialize)]

--- a/benches/templates.rs
+++ b/benches/templates.rs
@@ -26,7 +26,7 @@ pub fn big_table(b: &mut test::Bencher) {
     let mut ctx = Context::new();
     ctx.insert("table", &table);
 
-    b.iter(|| tera.render("big-table.html", ctx.clone()));
+    b.iter(|| tera.render("big-table.html", &ctx));
 }
 
 static BIG_TABLE_TEMPLATE: &'static str = "<table>
@@ -57,7 +57,7 @@ pub fn teams(b: &mut test::Bencher) {
         ],
     );
 
-    b.iter(|| tera.render("teams.html", ctx.clone()));
+    b.iter(|| tera.render("teams.html", &ctx));
 }
 
 static TEAMS_TEMPLATE: &'static str = "<html>

--- a/benches/tera.rs
+++ b/benches/tera.rs
@@ -108,7 +108,7 @@ fn bench_rendering_only_variable(b: &mut test::Bencher) {
     context.insert("product", &Product::new());
     context.insert("username", &"bob");
 
-    b.iter(|| tera.render("test.html", context.clone()));
+    b.iter(|| tera.render("test.html", &context));
 }
 
 #[bench]
@@ -119,7 +119,7 @@ fn bench_rendering_basic_template(b: &mut test::Bencher) {
     context.insert("product", &Product::new());
     context.insert("username", &"bob");
 
-    b.iter(|| tera.render("bench.html", context.clone()));
+    b.iter(|| tera.render("bench.html", &context));
 }
 
 #[bench]
@@ -130,7 +130,7 @@ fn bench_rendering_only_parent(b: &mut test::Bencher) {
     context.insert("product", &Product::new());
     context.insert("username", &"bob");
 
-    b.iter(|| tera.render("parent.html", context.clone()));
+    b.iter(|| tera.render("parent.html", &context));
 }
 
 #[bench]
@@ -142,7 +142,7 @@ fn bench_rendering_only_macro_call(b: &mut test::Bencher) {
     context.insert("product", &Product::new());
     context.insert("username", &"bob");
 
-    b.iter(|| tera.render("hey.html", context.clone()));
+    b.iter(|| tera.render("hey.html", &context));
 }
 
 #[bench]
@@ -154,7 +154,7 @@ fn bench_rendering_only_inheritance(b: &mut test::Bencher) {
     context.insert("product", &Product::new());
     context.insert("username", &"bob");
 
-    b.iter(|| tera.render("child.html", context.clone()));
+    b.iter(|| tera.render("child.html", &context));
 }
 
 #[bench]
@@ -170,7 +170,7 @@ fn bench_rendering_inheritance_and_macros(b: &mut test::Bencher) {
     context.insert("product", &Product::new());
     context.insert("username", &"bob");
 
-    b.iter(|| tera.render("child.html", context.clone()));
+    b.iter(|| tera.render("child.html", &context));
 }
 
 #[bench]
@@ -208,7 +208,7 @@ fn bench_huge_loop(b: &mut test::Bencher) {
     let mut context = Context::new();
     context.insert("rows", &rows);
 
-    b.iter(|| tera.render("huge.html", context.clone()));
+    b.iter(|| tera.render("huge.html", &context));
 }
 
 fn deep_object() -> Value {
@@ -254,9 +254,9 @@ fn access_deep_object(b: &mut test::Bencher) {
     let mut context = Context::new();
     println!("{:?}", deep_object());
     context.insert("deep_object", &deep_object());
-    assert!(tera.render("deep_object.html", context.clone()).unwrap().contains("ornery"));
+    assert!(tera.render("deep_object.html", &context).unwrap().contains("ornery"));
 
-    b.iter(|| tera.render("deep_object.html", context.clone()));
+    b.iter(|| tera.render("deep_object.html", &context));
 }
 
 #[bench]
@@ -272,7 +272,7 @@ fn access_deep_object_with_literal(b: &mut test::Bencher) {
     .unwrap();
     let mut context = Context::new();
     context.insert("deep_object", &deep_object());
-    assert!(tera.render("deep_object.html", context.clone()).unwrap().contains("ornery"));
+    assert!(tera.render("deep_object.html", &context).unwrap().contains("ornery"));
 
-    b.iter(|| tera.render("deep_object.html", context.clone()));
+    b.iter(|| tera.render("deep_object.html", &context));
 }

--- a/examples/basic/main.rs
+++ b/examples/basic/main.rs
@@ -40,7 +40,7 @@ fn main() {
     // A one off template
     Tera::one_off("hello", Context::new(), true).unwrap();
 
-    match TEMPLATES.render("users/profile.html", context) {
+    match TEMPLATES.render("users/profile.html", &context) {
         Ok(s) => println!("{:?}", s),
         Err(e) => {
             println!("Error: {}", e);

--- a/examples/bench/main.rs
+++ b/examples/bench/main.rs
@@ -29,6 +29,6 @@ fn main() {
     let mut ctx = Context::new();
     ctx.insert("table", &table);
 
-    let _ = tera.render("big-table.html", ctx).unwrap();
+    let _ = tera.render("big-table.html", &ctx).unwrap();
     println!("Done!");
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -28,8 +28,8 @@ impl Context {
     /// // user is an instance of a struct implementing `Serialize`
     /// context.insert("number_users", 42);
     /// ```
-    pub fn insert<T: Serialize + ?Sized>(&mut self, key: &str, val: &T) {
-        self.data.insert(key.to_owned(), to_value(val).unwrap());
+    pub fn insert<T: Serialize + ?Sized, S: Into<String>>(&mut self, key: S, val: &T) {
+        self.data.insert(key.into(), to_value(val).unwrap());
     }
 
     /// Appends the data of the `source` parameter to `self`, overwriting existing keys.
@@ -79,6 +79,10 @@ impl Context {
     pub fn from_serialize(value: impl Serialize) -> TeraResult<Self> {
         let obj = to_value(value).map_err(Error::json)?;
         Context::from_value(obj)
+    }
+
+    pub(crate) fn get(&self, index: &str) -> Option<&Value> {
+        self.data.get(index)
     }
 }
 

--- a/src/renderer/call_stack.rs
+++ b/src/renderer/call_stack.rs
@@ -8,17 +8,18 @@ use crate::errors::{Error, Result};
 use crate::renderer::for_loop::{ForLoop, ForLoopState};
 use crate::renderer::stack_frame::{FrameContext, FrameType, StackFrame, Val};
 use crate::template::Template;
+use crate::Context;
 
 /// Contains the user data and allows no mutation
 #[derive(Debug)]
 pub struct UserContext<'a> {
     /// Read-only context
-    inner: &'a Value,
+    inner: &'a Context,
 }
 
 impl<'a> UserContext<'a> {
     /// Create an immutable user context to be used in the call stack
-    pub fn new(context: &'a Value) -> Self {
+    pub fn new(context: &'a Context) -> Self {
         UserContext { inner: context }
     }
 
@@ -27,7 +28,10 @@ impl<'a> UserContext<'a> {
     }
 
     pub fn find_value_by_pointer(self: &Self, pointer: &str) -> Option<&'a Value> {
-        self.inner.pointer(pointer)
+        assert!(pointer.starts_with('/'));
+        let root = pointer.split('/').nth(1).unwrap().replace("~1", "/").replace("~0", "~");
+        let rest = &pointer[root.len() + 1..];
+        self.inner.get(&root).and_then(|val| val.pointer(rest))
     }
 }
 
@@ -42,7 +46,7 @@ pub struct CallStack<'a> {
 
 impl<'a> CallStack<'a> {
     /// Create the initial call stack
-    pub fn new(context: &'a Value, template: &'a Template) -> CallStack<'a> {
+    pub fn new(context: &'a Context, template: &'a Template) -> CallStack<'a> {
         CallStack {
             stack: vec![StackFrame::new(FrameType::Origin, "ORIGIN", template)],
             context: UserContext::new(context),
@@ -221,15 +225,10 @@ impl<'a> CallStack<'a> {
         // If we are here we take the user context
         // and add the values found in the stack to it.
         // We do it this way as we can override global variable temporarily in forloops
-        match self.context.inner.clone() {
-            Value::Object(mut m) => {
-                for (key, val) in context {
-                    m.insert(key.to_string(), val);
-                }
-
-                Value::Object(m)
-            }
-            _ => unreachable!("Had a context that wasn't a map?!"),
+        let mut new_ctx = self.context.inner.clone();
+        for (key, val) in context {
+            new_ctx.insert(key, &val)
         }
+        new_ctx.into_json()
     }
 }

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -8,12 +8,11 @@ mod macros;
 mod processor;
 mod stack_frame;
 
-use serde_json::value::Value;
-
 use self::processor::Processor;
 use crate::errors::Result;
 use crate::template::Template;
 use crate::tera::Tera;
+use crate::Context;
 
 /// Given a `Tera` and reference to `Template` and a `Context`, renders text
 #[derive(Debug)]
@@ -23,7 +22,7 @@ pub struct Renderer<'a> {
     /// Houses other templates, filters, global functions, etc
     tera: &'a Tera,
     /// Read-only context to be bound to template˝
-    context: Value,
+    context: &'a Context,
     /// If set rendering should be escaped
     should_escape: bool,
 }
@@ -31,7 +30,7 @@ pub struct Renderer<'a> {
 impl<'a> Renderer<'a> {
     /// Create a new `Renderer`
     #[inline]
-    pub fn new(template: &'a Template, tera: &'a Tera, context: Value) -> Renderer<'a> {
+    pub fn new(template: &'a Template, tera: &'a Tera, context: &'a Context) -> Renderer<'a> {
         let should_escape = tera.autoescape_suffixes.iter().any(|ext| {
             // We prefer a `path` if set, otherwise use the `name`
             if let Some(ref p) = template.path {

--- a/src/renderer/processor.rs
+++ b/src/renderer/processor.rs
@@ -13,6 +13,7 @@ use crate::renderer::square_brackets::pull_out_square_bracket;
 use crate::renderer::stack_frame::{FrameContext, FrameType, Val};
 use crate::template::Template;
 use crate::tera::Tera;
+use crate::Context;
 
 /// Special string indicating request to dump context
 static MAGICAL_DUMP_VAR: &str = "__tera_context";
@@ -120,7 +121,7 @@ impl<'a> Processor<'a> {
     pub fn new(
         template: &'a Template,
         tera: &'a Tera,
-        context: &'a Value,
+        context: &'a Context,
         should_escape: bool,
     ) -> Self {
         // Gets the root template if we are rendering something with inheritance or just return

--- a/src/renderer/tests/basic.rs
+++ b/src/renderer/tests/basic.rs
@@ -14,7 +14,7 @@ use crate::tera::Tera;
 
 use super::Review;
 
-fn render_template(content: &str, context: Context) -> Result<String> {
+fn render_template(content: &str, context: &Context) -> Result<String> {
     let mut tera = Tera::default();
     tera.add_raw_template("hello.html", content).unwrap();
     tera.register_function("get_number", |_: &HashMap<String, Value>| Ok(Value::Number(10.into())));
@@ -28,7 +28,7 @@ fn render_template(content: &str, context: Context) -> Result<String> {
 
 #[test]
 fn render_simple_string() {
-    let result = render_template("<h1>Hello world</h1>", Context::new());
+    let result = render_template("<h1>Hello world</h1>", &Context::new());
     assert_eq!(result.unwrap(), "<h1>Hello world</h1>".to_owned());
 }
 
@@ -63,7 +63,7 @@ fn render_variable_block_lit_expr() {
 
     for (input, expected) in inputs {
         println!("{:?} -> {:?}", input, expected);
-        assert_eq!(render_template(input, Context::new()).unwrap(), expected);
+        assert_eq!(render_template(input, &Context::new()).unwrap(), expected);
     }
 }
 
@@ -130,7 +130,7 @@ fn render_variable_block_ident() {
 
     for (input, expected) in inputs {
         println!("{:?} -> {:?}", input, expected);
-        assert_eq!(render_template(input, context.clone()).unwrap(), expected);
+        assert_eq!(render_template(input, &context).unwrap(), expected);
     }
 }
 
@@ -182,7 +182,7 @@ fn render_variable_block_logic_expr() {
 
     for (input, expected) in inputs {
         println!("{:?} -> {:?}", input, expected);
-        assert_eq!(render_template(input, context.clone()).unwrap(), expected);
+        assert_eq!(render_template(input, &context).unwrap(), expected);
     }
 }
 
@@ -204,7 +204,7 @@ fn render_variable_block_autoescaping_disabled() {
     for (input, expected) in inputs {
         let mut tera = Tera::default();
         tera.add_raw_template("hello.sql", input).unwrap();
-        assert_eq!(tera.render("hello.sql", context.clone()).unwrap(), expected);
+        assert_eq!(tera.render("hello.sql", &context).unwrap(), expected);
     }
 }
 
@@ -218,7 +218,7 @@ fn comments_are_ignored() {
 
     for (input, expected) in inputs {
         println!("{:?} -> {:?}", input, expected);
-        assert_eq!(render_template(input, Context::new()).unwrap(), expected);
+        assert_eq!(render_template(input, &Context::new()).unwrap(), expected);
     }
 }
 
@@ -236,7 +236,7 @@ fn escaping_happens_at_the_end() {
     for (input, expected) in inputs {
         let mut context = Context::new();
         context.insert("url", "https://www.example.org/apples-&-oranges/");
-        assert_eq!(render_template(input, context.clone()).unwrap(), expected);
+        assert_eq!(render_template(input, &context).unwrap(), expected);
     }
 }
 
@@ -247,7 +247,7 @@ fn filter_args_are_not_escaped() {
     context.insert("to", &"&");
     let input = r#"{{ my_var | replace(from="h", to=to) }}"#;
 
-    assert_eq!(render_template(input, context).unwrap(), "&amp;ey");
+    assert_eq!(render_template(input, &context).unwrap(), "&amp;ey");
 }
 
 #[test]
@@ -258,7 +258,7 @@ fn render_include_tag() {
         ("hello", "<h1>Hello {% include \"world\" %}</h1>"),
     ])
     .unwrap();
-    let result = tera.render("hello", Context::new()).unwrap();
+    let result = tera.render("hello", &Context::new()).unwrap();
     assert_eq!(result, "<h1>Hello world</h1>".to_owned());
 }
 
@@ -270,7 +270,7 @@ fn can_set_variables_in_included_templates() {
         ("hello", "<h1>Hello {% include \"world\" %}</h1>"),
     ])
     .unwrap();
-    let result = tera.render("hello", Context::new()).unwrap();
+    let result = tera.render("hello", &Context::new()).unwrap();
     assert_eq!(result, "<h1>Hello world</h1>".to_owned());
 }
 
@@ -284,7 +284,7 @@ fn render_raw_tag() {
 
     for (input, expected) in inputs {
         println!("{:?} -> {:?}", input, expected);
-        assert_eq!(render_template(input, Context::new()).unwrap(), expected);
+        assert_eq!(render_template(input, &Context::new()).unwrap(), expected);
     }
 }
 
@@ -315,7 +315,7 @@ fn add_set_values_in_context() {
 
     for (input, expected) in inputs {
         println!("{:?} -> {:?}", input, expected);
-        assert_eq!(render_template(input, context.clone()).unwrap(), expected);
+        assert_eq!(render_template(input, &context).unwrap(), expected);
     }
 }
 
@@ -335,7 +335,7 @@ fn render_filter_section() {
     let context = Context::new();
     for (input, expected) in inputs {
         println!("{:?} -> {:?}", input, expected);
-        assert_eq!(render_template(input, context.clone()).unwrap(), expected);
+        assert_eq!(render_template(input, &context).unwrap(), expected);
     }
 }
 
@@ -372,7 +372,7 @@ fn render_tests() {
 
     for (input, expected) in inputs {
         println!("{:?} -> {:?}", input, expected);
-        assert_eq!(render_template(input, context.clone()).unwrap(), expected);
+        assert_eq!(render_template(input, &context).unwrap(), expected);
     }
 }
 
@@ -439,7 +439,7 @@ fn render_if_elif_else() {
 
     for (input, expected) in inputs {
         println!("{:?} -> {:?}", input, expected);
-        assert_eq!(render_template(input, context.clone()).unwrap(), expected);
+        assert_eq!(render_template(input, &context).unwrap(), expected);
     }
 }
 
@@ -530,7 +530,7 @@ fn render_for() {
 
     for (input, expected) in inputs {
         println!("{:?} -> {:?}", input, expected);
-        assert_eq!(render_template(input, context.clone()).unwrap(), expected);
+        assert_eq!(render_template(input, &context).unwrap(), expected);
     }
 }
 
@@ -539,7 +539,7 @@ fn render_magic_variable_isnt_escaped() {
     let mut context = Context::new();
     context.insert("html", &"<html>");
 
-    let result = render_template("{{ __tera_context }}", context);
+    let result = render_template("{{ __tera_context }}", &context);
 
     assert_eq!(
         result.unwrap(),
@@ -564,7 +564,7 @@ fn ok_many_variable_blocks() {
     for _ in 0..200 {
         expected.push_str("bob")
     }
-    assert_eq!(render_template(&tpl, context).unwrap(), expected);
+    assert_eq!(render_template(&tpl, &context).unwrap(), expected);
 }
 
 #[test]
@@ -580,7 +580,7 @@ fn can_set_variable_in_global_context_in_forloop() {
 {%- set_global global_val = i -%}
 {%- endfor -%}
 {{ default }}{{ global_val }}"#,
-        context,
+        &context,
     );
 
     assert_eq!(result.unwrap(), "default3");
@@ -607,7 +607,7 @@ fn default_filter_works() {
 
     for (input, expected) in inputs {
         println!("{:?} -> {:?}", input, expected);
-        assert_eq!(render_template(input, context.clone()).unwrap(), expected);
+        assert_eq!(render_template(input, &context).unwrap(), expected);
     }
 }
 
@@ -626,7 +626,7 @@ fn filter_filter_works() {
 
     for (input, expected) in inputs {
         println!("{:?} -> {:?}", input, expected);
-        assert_eq!(render_template(input, context.clone()).unwrap(), expected);
+        assert_eq!(render_template(input, &context).unwrap(), expected);
     }
 }
 
@@ -655,7 +655,7 @@ fn can_do_string_concat() {
 
     for (input, expected) in inputs {
         println!("{:?} -> {:?}", input, expected);
-        assert_eq!(render_template(input, context.clone()).unwrap(), expected);
+        assert_eq!(render_template(input, &context).unwrap(), expected);
     }
 }
 
@@ -665,7 +665,7 @@ fn can_fail_rendering_from_template() {
     context.insert("title", "hello");
     let res = render_template(
         r#"{{ throw(message="Error: " ~ title ~ " did not include a summary") }}"#,
-        context,
+        &context,
     );
     assert!(res.is_err());
     let err = res.unwrap_err();
@@ -691,7 +691,7 @@ fn does_render_owned_for_loop_with_objects() {
     let tpl =
         r#"{% for year, things in something | group_by(attribute="year") %}{{year}},{% endfor %}"#;
     let expected = "2015,2016,2017,2018,";
-    assert_eq!(render_template(tpl, context).unwrap(), expected);
+    assert_eq!(render_template(tpl, &context).unwrap(), expected);
 }
 
 #[test]
@@ -713,7 +713,7 @@ fn does_render_owned_for_loop_with_objects_string_keys() {
     let tpl =
         r#"{% for group, things in something | group_by(attribute="group") %}{{group}},{% endfor %}"#;
     let expected = "a,b,c,";
-    assert_eq!(render_template(tpl, context).unwrap(), expected);
+    assert_eq!(render_template(tpl, &context).unwrap(), expected);
 }
 
 #[test]
@@ -725,7 +725,7 @@ fn render_magic_variable_gets_all_contexts() {
 
     let result = render_template(
         "{% set some_val = 1 %}{% for i in range(start=0, end=1) %}{% set for_val = i %}{{ __tera_context }}{% endfor %}",
-        context
+        &context
     );
 
     assert_eq!(
@@ -754,7 +754,7 @@ fn render_magic_variable_macro_doesnt_leak() {
         ("tpl", "{% import \"macros\" as macros %}{{macros::hello()}}"),
     ])
     .unwrap();
-    let result = tera.render("tpl", context);
+    let result = tera.render("tpl", &context);
 
     assert_eq!(
         result.unwrap(),
@@ -781,7 +781,7 @@ fn redefining_loop_value_doesnt_break_loop() {
     )
     .unwrap();
     let context = Context::new();
-    let result = tera.render("tpl", context);
+    let result = tera.render("tpl", &context);
 
     assert_eq!(result.unwrap(), "abclol efghlol ijklmlol ");
 }
@@ -800,7 +800,7 @@ fn can_use_concat_to_push_to_array() {
     )
     .unwrap();
     let context = Context::new();
-    let result = tera.render("tpl", context);
+    let result = tera.render("tpl", &context);
 
     assert_eq!(result.unwrap(), "[0, 1, 2, 3, 4]");
 }
@@ -842,11 +842,11 @@ fn stateful_global_fn() {
     }
 
     assert_eq!(
-        make_tera().render("fn.html", Context::new()).unwrap(),
+        make_tera().render("fn.html", &Context::new()).unwrap(),
         "<h1>1, 1, 2...</h1>".to_owned()
     );
     assert_eq!(
-        make_tera().render("fn.html", Context::new()).unwrap(),
+        make_tera().render("fn.html", &Context::new()).unwrap(),
         "<h1>1, 2, 2...</h1>".to_owned()
     );
 }
@@ -858,7 +858,7 @@ fn split_on_context_value() {
     tera.add_raw_template("split.html", r#"{{ body | split(pat="\n") }}"#).unwrap();
     let mut context = Context::new();
     context.insert("body", "multi\nple\nlines");
-    let res = tera.render("split.html", context);
+    let res = tera.render("split.html", &context);
     assert_eq!(res.unwrap(), "[multi, ple, lines]");
 }
 
@@ -868,6 +868,6 @@ fn default_filter_works_in_condition() {
     let mut tera = Tera::default();
     tera.add_raw_template("test.html", r#"{% if frobnicate|default(value=True) %}here{% endif %}"#)
         .unwrap();
-    let res = tera.render("test.html", Context::new());
+    let res = tera.render("test.html", &Context::new());
     assert_eq!(res.unwrap(), "here");
 }

--- a/src/renderer/tests/basic.rs
+++ b/src/renderer/tests/basic.rs
@@ -350,7 +350,7 @@ fn render_tests() {
     map.insert(0, 1);
     context.insert("map", &map);
     context.insert("numbers", &vec![1, 2, 3]);
-    context.insert::<Option<usize>>("maybe", &None);
+    context.insert::<Option<usize>, _>("maybe", &None);
 
     let inputs = vec![
         ("{% if is_true is defined %}Admin{% endif %}", "Admin"),

--- a/src/renderer/tests/errors.rs
+++ b/src/renderer/tests/errors.rs
@@ -9,7 +9,7 @@ fn error_location_basic() {
     let mut tera = Tera::default();
     tera.add_raw_templates(vec![("tpl", "{{ 1 + true }}")]).unwrap();
 
-    let result = tera.render("tpl", Context::new());
+    let result = tera.render("tpl", &Context::new());
 
     assert_eq!(result.unwrap_err().to_string(), "Failed to render \'tpl\'");
 }
@@ -23,7 +23,7 @@ fn error_location_inside_macro() {
     ])
     .unwrap();
 
-    let result = tera.render("tpl", Context::new());
+    let result = tera.render("tpl", &Context::new());
 
     assert_eq!(
         result.unwrap_err().to_string(),
@@ -40,7 +40,7 @@ fn error_loading_macro_from_unloaded_namespace() {
     ])
     .unwrap();
 
-    let result = tera.render("tpl", Context::new());
+    let result = tera.render("tpl", &Context::new());
     println!("{:#?}", result);
     assert_eq!(
         result.unwrap_err().source().unwrap().to_string(),
@@ -57,7 +57,7 @@ fn error_location_base_template() {
     ])
     .unwrap();
 
-    let result = tera.render("child", Context::new());
+    let result = tera.render("child", &Context::new());
 
     assert_eq!(
         result.unwrap_err().to_string(),
@@ -74,7 +74,7 @@ fn error_location_in_parent_block() {
     ])
     .unwrap();
 
-    let result = tera.render("child", Context::new());
+    let result = tera.render("child", &Context::new());
 
     assert_eq!(
         result.unwrap_err().to_string(),
@@ -91,7 +91,7 @@ fn error_location_in_parent_in_macro() {
         ("child", "{% extends \"parent\" %}{% block bob %}{{ super() }}Hey{% endblock bob %}"),
     ]).unwrap();
 
-    let result = tera.render("child", Context::new());
+    let result = tera.render("child", &Context::new());
 
     assert_eq!(
         result.unwrap_err().to_string(),
@@ -106,7 +106,7 @@ fn error_out_of_range_index() {
     let mut context = Context::new();
     context.insert("arr", &[1, 2, 3]);
 
-    let result = tera.render("tpl", Context::new());
+    let result = tera.render("tpl", &Context::new());
 
     assert_eq!(
         result.unwrap_err().source().unwrap().to_string(),
@@ -121,7 +121,7 @@ fn error_unknown_index_variable() {
     let mut context = Context::new();
     context.insert("arr", &[1, 2, 3]);
 
-    let result = tera.render("tpl", context);
+    let result = tera.render("tpl", &context);
 
     assert_eq!(
         result.unwrap_err().source().unwrap().to_string(),
@@ -138,7 +138,7 @@ fn error_invalid_type_index_variable() {
     context.insert("arr", &[1, 2, 3]);
     context.insert("a", &true);
 
-    let result = tera.render("tpl", context);
+    let result = tera.render("tpl", &context);
 
     assert_eq!(
         result.unwrap_err().source().unwrap().to_string(),
@@ -169,7 +169,7 @@ fn error_when_using_variable_set_in_included_templates_outside() {
     .unwrap();
     let mut context = Context::new();
     context.insert("a", &10);
-    let result = tera.render("base", context);
+    let result = tera.render("base", &context);
 
     assert_eq!(
         result.unwrap_err().source().unwrap().to_string(),
@@ -196,7 +196,7 @@ fn right_variable_name_is_needed_in_for_loop() {
 {% endfor -%}"#,
     )
     .unwrap();
-    let result = tera.render("tpl", context);
+    let result = tera.render("tpl", &context);
 
     assert_eq!(
         result.unwrap_err().source().unwrap().to_string(),
@@ -223,7 +223,7 @@ fn errors_when_calling_macros_defined_in_file() {
     .unwrap();
     let mut context = Context::new();
     context.insert("hello", &true);
-    let result = tera.render("tpl", context);
+    let result = tera.render("tpl", &context);
     assert_eq!(
         result.unwrap_err().source().unwrap().to_string(),
         "Invalid macro definition: `path_item`"
@@ -242,7 +242,7 @@ fn errors_with_inheritance_in_included_template() {
     ])
     .unwrap();
 
-    let result = tera.render("base", Context::new());
+    let result = tera.render("base", &Context::new());
 
     assert_eq!(
         result.unwrap_err().source().unwrap().to_string(),
@@ -257,7 +257,7 @@ fn error_string_concat_math_logic() {
     let mut context = Context::new();
     context.insert("name", &"john");
 
-    let result = tera.render("tpl", context);
+    let result = tera.render("tpl", &context);
 
     assert_eq!(
         result.unwrap_err().source().unwrap().to_string(),

--- a/src/renderer/tests/inheritance.rs
+++ b/src/renderer/tests/inheritance.rs
@@ -9,7 +9,7 @@ fn render_simple_inheritance() {
         ("bottom", "{% extends \"top\" %}{% block main %}MAIN{% endblock %}"),
     ])
     .unwrap();
-    let result = tera.render("bottom", Context::new());
+    let result = tera.render("bottom", &Context::new());
 
     assert_eq!(result.unwrap(), "MAIN".to_string());
 }
@@ -22,7 +22,7 @@ fn render_simple_inheritance_super() {
         ("bottom", "{% extends \"top\" %}{% block main %}{{ super() }}MAIN{% endblock %}"),
     ])
     .unwrap();
-    let result = tera.render("bottom", Context::new());
+    let result = tera.render("bottom", &Context::new());
 
     assert_eq!(result.unwrap(), "TOPMAIN".to_string());
 }
@@ -36,7 +36,7 @@ fn render_multiple_inheritance() {
         ("bottom", "{% extends \"mid\" %}{% block main %}MAIN{% endblock main %}"),
     ])
     .unwrap();
-    let result = tera.render("bottom", Context::new());
+    let result = tera.render("bottom", &Context::new());
 
     assert_eq!(result.unwrap(), "PREMAIN".to_string());
 }
@@ -58,7 +58,7 @@ fn render_multiple_inheritance_with_super() {
             "{% extends \"parent\" %}{% block hey %}dad says {{ super() }}{% endblock hey %}{% block ending %}{{ super() }} with love{% endblock ending %}",
         ),
     ]).unwrap();
-    let result = tera.render("child", Context::new());
+    let result = tera.render("child", &Context::new());
 
     assert_eq!(
         result.unwrap(),
@@ -82,7 +82,7 @@ fn render_super_multiple_inheritance_nested_block() {
             "child", "{% extends \"parent\" %}{% block hey %}dad says {{ super() }}{% endblock hey %}{% block ending %}{{ super() }} with love{% endblock ending %}",
         ),
     ]).unwrap();
-    let result = tera.render("child", Context::new());
+    let result = tera.render("child", &Context::new());
 
     assert_eq!(
         result.unwrap(),
@@ -102,7 +102,7 @@ fn render_nested_block_multiple_inheritance_no_super() {
         ("page", "{% extends \"docs\" %}{% block more %}PAGE{% endblock more %}"),
     ]).unwrap();
 
-    let result = tera.render("page", Context::new());
+    let result = tera.render("page", &Context::new());
 
     assert_eq!(result.unwrap(), "DOCSPAGE".to_string());
 }
@@ -113,7 +113,7 @@ fn render_super_in_top_block_errors() {
     tera.add_raw_templates(vec![("index", "{% block content%}{{super()}}{% endblock content %}")])
         .unwrap();
 
-    let result = tera.render("index", Context::new());
+    let result = tera.render("index", &Context::new());
     assert!(result.is_err());
 }
 
@@ -131,7 +131,7 @@ fn render_super_in_grandchild_without_redefining_works() {
     ])
     .unwrap();
 
-    let result = tera.render("child", Context::new());
+    let result = tera.render("child", &Context::new());
     assert_eq!(result.unwrap(), "Title - More".to_string());
 }
 
@@ -145,6 +145,6 @@ fn render_super_in_grandchild_without_redefining_in_parent_works() {
     ])
     .unwrap();
 
-    let result = tera.render("child", Context::new());
+    let result = tera.render("child", &Context::new());
     assert_eq!(result.unwrap(), "Title - More".to_string());
 }

--- a/src/renderer/tests/macros.rs
+++ b/src/renderer/tests/macros.rs
@@ -15,7 +15,7 @@ fn render_macros() {
     ])
     .unwrap();
 
-    let result = tera.render("tpl", Context::new());
+    let result = tera.render("tpl", &Context::new());
 
     assert_eq!(result.unwrap(), "Hello".to_string());
 }
@@ -31,7 +31,7 @@ fn render_macros_expression_arg() {
     ])
     .unwrap();
 
-    let result = tera.render("tpl", context);
+    let result = tera.render("tpl", &context);
 
     assert_eq!(result.unwrap(), "5".to_string());
 }
@@ -47,7 +47,7 @@ fn render_macros_in_child_templates_same_namespace() {
         ("child", "{% extends \"parent\" %}{% import \"macros2\" as macros %}{% block hey %}{{super()}}/{{macros::hi()}}{% endblock hey %}"),
     ]).unwrap();
 
-    let result = tera.render("child", Context::new());
+    let result = tera.render("child", &Context::new());
 
     assert_eq!(result.unwrap(), "Hello/Hi".to_string());
 }
@@ -63,7 +63,7 @@ fn render_macros_in_child_templates_different_namespace() {
         ("child", "{% extends \"parent\" %}{% import \"macros2\" as macros2 %}{% block hey %}{{super()}}/{{macros2::hi()}}{% endblock hey %}"),
     ]).unwrap();
 
-    let result = tera.render("child", Context::new());
+    let result = tera.render("child", &Context::new());
 
     assert_eq!(result.unwrap(), "Hello/Hi".to_string());
 }
@@ -77,7 +77,7 @@ fn render_macros_in_parent_template_with_inheritance() {
         ("child", "{% extends \"grandparent\" %}{% import \"macros\" as macros %}{% block hey %}{{super()}}/{{macros::hello()}}{% endblock hey %}"),
     ]).unwrap();
 
-    let result = tera.render("child", Context::new());
+    let result = tera.render("child", &Context::new());
 
     assert_eq!(result.unwrap(), "Hello/Hello".to_string());
 }
@@ -92,7 +92,7 @@ fn macro_param_arent_escaped() {
     .unwrap();
     let mut context = Context::new();
     context.insert("my_var", &"&");
-    let result = tera.render("hello.html", context);
+    let result = tera.render("hello.html", &context);
 
     assert_eq!(result.unwrap(), "&".to_string());
 }
@@ -108,7 +108,7 @@ fn render_set_tag_macro() {
         ),
     ])
     .unwrap();
-    let result = tera.render("hello.html", Context::new());
+    let result = tera.render("hello.html", &Context::new());
 
     assert_eq!(result.unwrap(), "Hello".to_string());
 }
@@ -121,7 +121,7 @@ fn render_macros_with_default_args() {
         ("hello.html", "{% import \"macros\" as macros %}{{macros::hello()}}"),
     ])
     .unwrap();
-    let result = tera.render("hello.html", Context::new());
+    let result = tera.render("hello.html", &Context::new());
 
     assert_eq!(result.unwrap(), "1".to_string());
 }
@@ -134,7 +134,7 @@ fn render_macros_override_default_args() {
         ("hello.html", "{% import \"macros\" as macros %}{{macros::hello(val=2)}}"),
     ])
     .unwrap();
-    let result = tera.render("hello.html", Context::new());
+    let result = tera.render("hello.html", &Context::new());
 
     assert_eq!(result.unwrap(), "2".to_string());
 }
@@ -149,7 +149,7 @@ fn render_recursive_macro() {
         ),
         ("hello.html", "{% import \"macros\" as macros %}{{macros::factorial(n=7)}}"),
     ]).unwrap();
-    let result = tera.render("hello.html", Context::new());
+    let result = tera.render("hello.html", &Context::new());
 
     assert_eq!(result.unwrap(), "7 - 6 - 5 - 4 - 3 - 2 - 11234567".to_string());
 }
@@ -192,7 +192,7 @@ fn recursive_macro_with_loops() {
     ])
     .unwrap();
 
-    let result = tera.render("recursive", context);
+    let result = tera.render("recursive", &context);
 
     assert_eq!(result.unwrap(), "Parent123|Child123".to_string());
 }
@@ -207,7 +207,7 @@ fn render_macros_in_included() {
         ("example", r#"{% include "includeme" %}"#),
     ])
     .unwrap();
-    let result = tera.render("example", Context::new());
+    let result = tera.render("example", &Context::new());
 
     assert_eq!(result.unwrap(), "my macro".to_string());
 }
@@ -225,7 +225,7 @@ fn import_macros_into_other_macro_files() {
         ("index", r#"{% import "macros" as macros %}{{ macros::test() }}"#),
     ])
     .unwrap();
-    let result = tera.render("index", Context::new());
+    let result = tera.render("index", &Context::new());
 
     assert_eq!(result.unwrap(), "Success!".to_string());
 }
@@ -239,7 +239,7 @@ fn can_load_parent_macro_in_child() {
         ("child", "{% extends \"parent\" %}{% block bob %}{{ super() }}Hey{% endblock bob %}"),
     ]).unwrap();
 
-    let result = tera.render("child", Context::new());
+    let result = tera.render("child", &Context::new());
 
     assert_eq!(result.unwrap(), "1Hey".to_string());
 }
@@ -253,7 +253,7 @@ fn can_load_macro_in_child() {
         ("child", "{% extends \"parent\" %}{% import \"macros\" as macros %}{% block bob %}{{ macros::hello() }}{% endblock bob %}"),
     ]).unwrap();
 
-    let result = tera.render("child", Context::new());
+    let result = tera.render("child", &Context::new());
 
     assert_eq!(result.unwrap(), "1".to_string());
 }
@@ -270,7 +270,7 @@ fn can_inherit_macro_import_from_parent() {
     ])
     .unwrap();
 
-    let result = tera.render("child", Context::default());
+    let result = tera.render("child", &Context::default());
     assert_eq!(result.unwrap(), "HELLO".to_string());
 }
 
@@ -284,7 +284,7 @@ fn can_inherit_macro_import_from_grandparent() {
         ("child", "{% extends \"parent\" %}{% block bob %}{{macros::hello()}}-{{macros2::hello()}}{% endblock bob %}"),
     ]).unwrap();
 
-    let result = tera.render("child", Context::default());
+    let result = tera.render("child", &Context::default());
     assert_eq!(result.unwrap(), "HELLO-HELLO".to_string());
 }
 
@@ -298,7 +298,7 @@ fn can_load_macro_in_parent_with_grandparent() {
         ("child", "{% extends \"parent\" %}{% block bob %}{{ super() }}{% endblock bob %}"),
     ]).unwrap();
 
-    let result = tera.render("child", Context::new());
+    let result = tera.render("child", &Context::new());
 
     assert_eq!(result.unwrap(), "1 - Hey".to_string());
 }
@@ -313,7 +313,7 @@ fn macro_can_load_macro_from_macro_files() {
         ("child", "{% extends \"parent\" %}{% import \"macros\" as macros %}{% block main %}{{ macros::hommage() }}{% endblock main %}")
     ]).unwrap();
 
-    let result = tera.render("child", Context::new());
+    let result = tera.render("child", &Context::new());
     //println!("{:#?}", result);
     assert_eq!(result.unwrap(), "Emma was an amazing person! Don't you think?".to_string());
 }
@@ -326,7 +326,7 @@ fn macro_can_access_global_context() {
         ("macros", r#"{% macro test_global() %}{% set_global value1 = "42" %}{% for i in range(end=1) %}{% set_global value2 = " is the truth." %}{% endfor %}{{ value1 }}{% endmacro test_global %}"#)
     ]).unwrap();
 
-    let result = tera.render("parent", Context::new());
+    let result = tera.render("parent", &Context::new());
     assert_eq!(result.unwrap(), "42".to_string());
 }
 
@@ -338,7 +338,7 @@ fn template_cant_access_macros_context() {
         ("macros", r#"{% macro empty() %}{% set_global quote = "This should not reachable from the calling template!" %}{% endmacro empty %}"#)
     ]).unwrap();
 
-    let result = tera.render("parent", Context::new());
+    let result = tera.render("parent", &Context::new());
     assert_eq!(result.unwrap(), "I'd rather have roses on my table than diamonds on my neck.");
 }
 
@@ -351,6 +351,6 @@ fn parent_macro_cant_access_child_macro_context() {
         ("moremacros", r#"{% macro another_one() %}{% set_global value2 = "1312" %}{% endmacro another_one %}"#)
     ]).unwrap();
 
-    let result = tera.render("parent", Context::new());
+    let result = tera.render("parent", &Context::new());
     assert_eq!(result.unwrap(), "ACAB-ACAB".to_string());
 }

--- a/src/renderer/tests/whitespace.rs
+++ b/src/renderer/tests/whitespace.rs
@@ -27,7 +27,7 @@ fn can_remove_whitespace_basic() {
     for (input, expected) in inputs {
         let mut tera = Tera::default();
         tera.add_raw_template("tpl", input).unwrap();
-        assert_eq!(tera.render("tpl", context.clone()).unwrap(), expected);
+        assert_eq!(tera.render("tpl", &context).unwrap(), expected);
     }
 }
 
@@ -45,7 +45,7 @@ fn can_remove_whitespace_include() {
     for (input, expected) in inputs {
         let mut tera = Tera::default();
         tera.add_raw_templates(vec![("include", "Included"), ("tpl", input)]).unwrap();
-        assert_eq!(tera.render("tpl", context.clone()).unwrap(), expected);
+        assert_eq!(tera.render("tpl", &context).unwrap(), expected);
     }
 }
 
@@ -67,7 +67,7 @@ fn can_remove_whitespace_macros() {
             ("tpl", input),
         ])
         .unwrap();
-        assert_eq!(tera.render("tpl", context.clone()).unwrap(), expected);
+        assert_eq!(tera.render("tpl", &context).unwrap(), expected);
     }
 }
 
@@ -89,6 +89,6 @@ fn can_remove_whitespace_inheritance() {
             ("tpl", input),
         ])
         .unwrap();
-        assert_eq!(tera.render("tpl", context.clone()).unwrap(), expected);
+        assert_eq!(tera.render("tpl", &context).unwrap(), expected);
     }
 }

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -15,7 +15,6 @@ use crate::errors::{Error, Result};
 use crate::renderer::Renderer;
 use crate::template::Template;
 use crate::utils::escape_html;
-use std::borrow::Borrow;
 
 /// The escape function type definition
 pub type EscapeFn = fn(&str) -> String;
@@ -300,9 +299,9 @@ impl Tera {
     /// // Rendering a template with an empty context
     /// tera.render("hello.html", Context::new());
     /// ```
-    pub fn render<C: Borrow<Context>>(&self, template_name: &str, context: C) -> Result<String> {
+    pub fn render(&self, template_name: &str, context: &Context) -> Result<String> {
         let template = self.get_template(template_name)?;
-        let renderer = Renderer::new(template, self, context.borrow());
+        let renderer = Renderer::new(template, self, context);
         renderer.render()
     }
 
@@ -840,7 +839,7 @@ mod tests {
         tera.set_escape_fn(escape_c_string);
         let mut context = Context::new();
         context.insert("content", &"Hello\n\'world\"!");
-        let result = tera.render("foo", context).unwrap();
+        let result = tera.render("foo", &context).unwrap();
         assert_eq!(result, r#""Hello\n\'world\"!""#);
     }
 
@@ -854,7 +853,7 @@ mod tests {
         tera.reset_escape_fn();
         let mut context = Context::new();
         context.insert("content", &"Hello\n\'world\"!");
-        let result = tera.render("foo", context).unwrap();
+        let result = tera.render("foo", &context).unwrap();
         assert_eq!(result, "Hello\n&#x27;world&quot;!");
     }
 
@@ -885,7 +884,7 @@ mod tests {
 
         my_tera.extend(&framework_tera).unwrap();
         assert_eq!(my_tera.templates.len(), 4);
-        let result = my_tera.render("four", Context::default()).unwrap();
+        let result = my_tera.render("four", &Context::default()).unwrap();
         assert_eq!(result, "Framework X");
     }
 
@@ -907,7 +906,7 @@ mod tests {
 
         my_tera.extend(&framework_tera).unwrap();
         assert_eq!(my_tera.templates.len(), 4);
-        let result = my_tera.render("one", Context::default()).unwrap();
+        let result = my_tera.render("one", &Context::default()).unwrap();
         assert_eq!(result, "MINE");
     }
 

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -15,6 +15,7 @@ use crate::errors::{Error, Result};
 use crate::renderer::Renderer;
 use crate::template::Template;
 use crate::utils::escape_html;
+use std::borrow::Borrow;
 
 /// The escape function type definition
 pub type EscapeFn = fn(&str) -> String;
@@ -299,9 +300,9 @@ impl Tera {
     /// // Rendering a template with an empty context
     /// tera.render("hello.html", Context::new());
     /// ```
-    pub fn render(&self, template_name: &str, context: Context) -> Result<String> {
+    pub fn render<C: Borrow<Context>>(&self, template_name: &str, context: C) -> Result<String> {
         let template = self.get_template(template_name)?;
-        let renderer = Renderer::new(template, self, context.into_json());
+        let renderer = Renderer::new(template, self, context.borrow());
         renderer.render()
     }
 
@@ -324,7 +325,7 @@ impl Tera {
             tera.autoescape_on(vec!["one_off"]);
         }
 
-        tera.render("one_off", context)
+        tera.render("one_off", &context)
     }
 
     #[doc(hidden)]

--- a/tests/render_fails.rs
+++ b/tests/render_fails.rs
@@ -18,7 +18,7 @@ fn render_tpl(tpl_name: &str) -> Result<String> {
     context.insert("show_more", &true);
     context.insert("reviews", &vec![Review::new(), Review::new()]);
 
-    tera.render(tpl_name, context)
+    tera.render(tpl_name, &context)
 }
 
 #[test]


### PR DESCRIPTION
Note that this does the minimal threading of using `Context` at the root layer required to get this to compile; it might be worth it to see where else `Context` can be used instead of a raw `Value`.

I made `Tera::render` take `impl Borrow<Context>` here so that it can continue to take `Context` by value to avoid having to change all of the tests to pass `&Context`. The function potentially should always take `&Context`, though, and the benchmarks definitely should be adjusted to pass `&context` to avoid the initial clone at least.