### PR TITLE
Made the Error struct Send + Sync

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -46,7 +46,7 @@ pub enum ErrorKind {
 pub struct Error {
     /// Kind of error
     pub kind: ErrorKind,
-    source: Option<Box<dyn StdError>>,
+    source: Option<Box<dyn StdError + Sync + Send>>,
 }
 
 impl fmt::Display for Error {
@@ -78,7 +78,7 @@ impl fmt::Display for Error {
 
 impl StdError for Error {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
-        self.source.as_ref().map(|c| &**c)
+        self.source.as_ref().map(|c| &**c as &(dyn StdError + 'static))
     }
 }
 
@@ -128,7 +128,7 @@ impl Error {
     }
 
     /// Creates generic error with a source
-    pub fn chain(value: impl ToString, source: impl Into<Box<dyn StdError>>) -> Self {
+    pub fn chain(value: impl ToString, source: impl Into<Box<dyn StdError + Send + Sync>>) -> Self {
         Self { kind: ErrorKind::Msg(value.to_string()), source: Some(source.into()) }
     }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -165,16 +165,8 @@ pub type Result<T> = ::std::result::Result<T, Error>;
 mod tests {
     #[test]
     fn test_error_is_send_and_sync() {
-        trait SendAndSyncTrait: Send + Sync {
-            fn very_useless_function();
-        }
+        fn test_send_sync<T: Send + Sync>() {}
 
-        impl SendAndSyncTrait for super::Error {
-            fn very_useless_function() {
-                println!("Yay!");
-            }
-        }
-
-        super::Error::very_useless_function();
+        test_send_sync::<super::Error>();
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -160,3 +160,21 @@ impl From<serde_json::Error> for Error {
 }
 /// Convenient wrapper around std::Result.
 pub type Result<T> = ::std::result::Result<T, Error>;
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_error_is_send_and_sync() {
+        trait SendAndSyncTrait: Send + Sync {
+            fn very_useless_function();
+        }
+
+        impl SendAndSyncTrait for super::Error {
+            fn very_useless_function() {
+                println!("Yay!");
+            }
+        }
+
+        super::Error::very_useless_function();
+    }
+}

--- a/tests/render_fails.rs
+++ b/tests/render_fails.rs
@@ -142,3 +142,18 @@ fn test_error_in_macro_location() {
         "Failed to render 'error-location/error_in_macro.html': error while rendering macro `macros::cause_error`"
     );
 }
+
+#[test]
+fn test_error_is_send_and_sync() {
+    trait SendAndSyncTrait: Send + Sync {
+        fn very_useless_function();
+    }
+
+    impl SendAndSyncTrait for tera::Error {
+        fn very_useless_function() {
+            println!("Yay!");
+        }
+    }
+
+    tera::Error::very_useless_function();
+}

--- a/tests/render_fails.rs
+++ b/tests/render_fails.rs
@@ -142,18 +142,3 @@ fn test_error_in_macro_location() {
         "Failed to render 'error-location/error_in_macro.html': error while rendering macro `macros::cause_error`"
     );
 }
-
-#[test]
-fn test_error_is_send_and_sync() {
-    trait SendAndSyncTrait: Send + Sync {
-        fn very_useless_function();
-    }
-
-    impl SendAndSyncTrait for tera::Error {
-        fn very_useless_function() {
-            println!("Yay!");
-        }
-    }
-
-    tera::Error::very_useless_function();
-}


### PR DESCRIPTION
In order to be able to construct `anyhow::Error`s from `tera::Error`s, we must make this crate errors `Send + Sync`.

To do so it's only necessary to change 3 lines of code, but I'm not sure whether this is going to be a breaking change or not.

IMO this is a small but great addition that contributes to the usability of this crate.

Edit:
Fixes #442 