### PR TITLE
And (&&) operator for windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,4 @@ jobs:
       run: cargo run --example basic
     - name: Build actix example
       run: cd examples/actix && cargo build
+      shell: bash


### PR DESCRIPTION
GitHub Actions CI fails on window because of the command `cd examples/actix && cargo build`.

The fix is to always use the bash shell, even on windows (git bash is used).

Edit:
I'm not sure why it's failing right now. Probably some recent changes to GitHub Actions broke the CI.