### PR TITLE
Fix code examples in `group_by` docs

### DIFF
--- a/docs/content/docs/templates.md
+++ b/docs/content/docs/templates.md
@@ -681,13 +681,13 @@ struct Post {
 The `attribute` argument can be used to group posts by year:
 
 ```jinja2
-{{ posts | sort(attribute="year") }}
+{{ posts | group_by(attribute="year") }}
 ```
 
 or by author name:
 
 ```jinja2
-{{ posts | sort(attribute="author.name") }}
+{{ posts | group_by(attribute="author.name") }}
 ```
 
 #### filter


### PR DESCRIPTION
They used the `sort` function instead of the `group_by` function that this section is about.