### PR TITLE
Add #[derive(Clone)] to Tera struct

### DIFF
--- a/src/tera.rs
+++ b/src/tera.rs
@@ -20,6 +20,7 @@ use crate::utils::escape_html;
 pub type EscapeFn = fn(&str) -> String;
 
 /// The main point of interaction in this library.
+#[derive(Clone)]
 pub struct Tera {
     // The glob used in `Tera::new`, None if Tera was instantiated differently
     #[doc(hidden)]


### PR DESCRIPTION
Hi,

I am using Tera v1 with actix-web v1. When constructing the app, I would prefer to clone Tera than parsing the templates as many times as there are workers.
