### PR TITLE
Use usize instead of i64 in filesizeformat filter

### DIFF
--- a/src/builtins/filters/number.rs
+++ b/src/builtins/filters/number.rs
@@ -62,7 +62,7 @@ pub fn round(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
 /// Returns a human-readable file size (i.e. '110 MB') from an integer
 #[cfg(feature = "builtins")]
 pub fn filesizeformat(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
-    let num = try_get_value!("filesizeformat", "value", i64, value);
+    let num = try_get_value!("filesizeformat", "value", usize, value);
     num.file_size(file_size_opts::CONVENTIONAL)
         .or_else(|_| {
             Err(Error::msg(format!(


### PR DESCRIPTION
Use of usize instead of i64 for 3 reasons:
- Become more permissive with upper values
- usize is more commonly used as file size unit
- humansize::file_size_opts::CONVENTIONAL doesn't allow negative values (and return an error in this case)