### PR TITLE
Fix GlobalFn in docs

### DIFF
--- a/docs/content/docs/_index.md
+++ b/docs/content/docs/_index.md
@@ -437,7 +437,7 @@ Functions are Rust code that return a `Result<Value>` from the given params.
 
 Quite often, functions will need to capture some external variables, such as a `url_for` global function needing
 the list of URLs for example.
-To make that work, the type of `GlobalFn` is a boxed closure: `Box<Fn(HashMap<String, Value>) -> Result<Value> + Sync + Send>`.
+To make that work, the type of `GlobalFn` is a boxed closure: `Box<Fn(&HashMap<String, Value>) -> Result<Value> + Sync + Send>`.
 
 Here's an example on how to implement a very basic function:
 


### PR DESCRIPTION
Wouldn't this be an opportunity to provide the alias GlobalFn in the API?