### PR TITLE
Add Tera::render_str

### DIFF
--- a/src/tera.rs
+++ b/src/tera.rs
@@ -324,9 +324,9 @@ impl Tera {
     /// ```
     pub fn render_str(&mut self, input: &str, context: &Context) -> Result<String> {
         self.add_raw_template(ONE_OFF_TEMPLATE_NAME, input)?;
-        let string = self.render(ONE_OFF_TEMPLATE_NAME, &context)?;
+        let result = self.render(ONE_OFF_TEMPLATE_NAME, &context);
         self.templates.remove(ONE_OFF_TEMPLATE_NAME);
-        Ok(string)
+        result
     }
 
     /// Renders a one off template (for example a template coming from a user input) given a `Context`


### PR DESCRIPTION
When creating a fluent integration with Tera, it is slightly annoying to need to register a template to be able to render a `Tera` instance with a custom function when testing. This PR adds `Tera::render_str` to handle that. It uses the code from `Tera::one_off`, and `Tera::one_off`, has been refactored to use this function instead. I opted to change the template name from `one_off` to `__one_off` in case anyone uses this for not testing it's less likely to conflict.