### PR TITLE
Add support for blocks in filter sections

### DIFF
--- a/docs/content/docs/_index.md
+++ b/docs/content/docs/_index.md
@@ -404,6 +404,15 @@ tags where `name` is the name of the filter:
 
 This example transforms the text `Hello` in all upper-case (`HELLO`).
 
+Filter sections can also contain [`block` sections](@/docs/_index.md#inheritance) like this:
+```jinja2
+{% filter upper %}
+  {% block content_to_be_upper_cased %}
+    This will be upper-cased
+  {% endblock content_to_be_upper_cased %} 
+{% endfilter %}
+```
+
 ### Tests
 
 Tests can be used against an expression to check some condition on it and

--- a/docs/templates/docs.html
+++ b/docs/templates/docs.html
@@ -7,7 +7,7 @@
     <div class="container">
         <nav class="docs__sidebar">
             <ul>
-                {% for h1 in toc %}
+                {% for h1 in section.toc %}
                     {% set index = loop.index %}
                     <li>
                         <a href="{{ h1.permalink }}">{{ h1.title }}</a>

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@
     command = "zola build"
 
 [build.environment]
-    ZOLA_VERSION = "0.9.0"
+    ZOLA_VERSION = "0.10.1"
 
 [context.deploy-preview]
     command = "zola build --base-url $DEPLOY_PRIME_URL"

--- a/src/parser/tera.pest
+++ b/src/parser/tera.pest
@@ -213,7 +213,7 @@ filter_section_content = @{
     comment_tag |
     set_tag |
     set_global_tag |
-     block |
+    block |
     forloop |
     filter_section_if |
     raw |

--- a/src/parser/tera.pest
+++ b/src/parser/tera.pest
@@ -213,6 +213,7 @@ filter_section_content = @{
     comment_tag |
     set_tag |
     set_global_tag |
+     block |
     forloop |
     filter_section_if |
     raw |

--- a/src/parser/tests/parser.rs
+++ b/src/parser/tests/parser.rs
@@ -375,7 +375,32 @@ fn parse_variable_tag_macro_call() {
                 namespace: "macros".to_string(),
                 name: "get_time".to_string(),
                 args,
-            },))
+            },)),
+        )
+    );
+}
+
+#[test]
+fn parse_allow_block_in_filter_section() {
+    let ast =
+        parse("{% filter upper %}{% block content %}Hello{% endblock %}{% endfilter %}").unwrap();
+
+    assert_eq!(
+        ast[0],
+        Node::FilterSection(
+            WS::default(),
+            FilterSection {
+                filter: FunctionCall { name: "upper".to_owned(), args: HashMap::default() },
+                body: vec![Node::Block(
+                    WS::default(),
+                    Block {
+                        name: "content".to_owned(),
+                        body: vec![Node::Text("Hello".to_owned())]
+                    },
+                    WS::default(),
+                )],
+            },
+            WS::default(),
         )
     );
 }

--- a/src/renderer/tests/inheritance.rs
+++ b/src/renderer/tests/inheritance.rs
@@ -67,6 +67,32 @@ fn render_multiple_inheritance_with_super() {
 }
 
 #[test]
+fn render_filter_section_inheritance_no_override() {
+    let mut tera = Tera::default();
+    tera.add_raw_templates(vec![
+        ("top", "{% filter upper %}hello {% block main %}top{% endblock main %}{% endfilter %}"),
+        ("bottom", "{% extends 'top' %}"),
+    ])
+    .unwrap();
+    let result = tera.render("bottom", &Context::new());
+
+    assert_eq!(result.unwrap(), "HELLO TOP".to_string());
+}
+
+#[test]
+fn render_filter_section_inheritance() {
+    let mut tera = Tera::default();
+    tera.add_raw_templates(vec![
+        ("top", "{% filter upper %}hello {% block main %}top{% endblock main %}{% endfilter %}"),
+        ("bottom", "{% extends 'top' %}{% block main %}bottom{% endblock %}"),
+    ])
+    .unwrap();
+    let result = tera.render("bottom", &Context::new());
+
+    assert_eq!(result.unwrap(), "HELLO BOTTOM".to_string());
+}
+
+#[test]
 fn render_super_multiple_inheritance_nested_block() {
     let mut tera = Tera::default();
     tera.add_raw_templates(vec![


### PR DESCRIPTION
This change allows blocks to be used in filter sections.
Also update docs zola version to the latest, `0.10.1`, and fix docs site
to build. `toc` had to be replaced with `section.toc`

## Docs Preview 
https://deploy-preview-496--tera.netlify.com/docs/#filter-sections