### PR TITLE
Add support for filters on array literals

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -519,6 +519,7 @@ fn parse_variable_tag(pair: Pair<Rule>) -> TeraResult<Node> {
                 ws.right = p.as_span().as_str() == "-}}";
             }
             Rule::logic_expr => expr = Some(parse_logic_expr(p)?),
+            Rule::array_filter => expr = Some(parse_array_with_filters(p)?),
             _ => unreachable!("unexpected {:?} rule in parse_variable_tag", p.as_rule()),
         }
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -66,7 +66,7 @@ fn parse_kwarg(pair: Pair<Rule>) -> TeraResult<(String, Expr)> {
         match p.as_rule() {
             Rule::ident => name = Some(p.as_span().as_str().to_string()),
             Rule::logic_expr => val = Some(parse_logic_expr(p)?),
-            Rule::array => val = Some(Expr::new(parse_array(p)?)),
+            Rule::array_filter => val = Some(parse_array_with_filters(p)?),
             _ => unreachable!("{:?} not supposed to get there (parse_kwarg)!", p.as_rule()),
         };
     }
@@ -305,11 +305,27 @@ fn parse_string_expr_with_filters(pair: Pair<Rule>) -> TeraResult<Expr> {
     Ok(Expr { val: expr_val.unwrap(), negated: false, filters })
 }
 
+/// An array with optional filters
+fn parse_array_with_filters(pair: Pair<Rule>) -> TeraResult<Expr> {
+    let mut array = None;
+    let mut filters = vec![];
+
+    for p in pair.into_inner() {
+        match p.as_rule() {
+            Rule::array => array = Some(parse_array(p)?),
+            Rule::filter => filters.push(parse_filter(p)?),
+            _ => unreachable!("Got {:?}", p),
+        };
+    }
+
+    Ok(Expr { val: array.unwrap(), negated: false, filters })
+}
+
 fn parse_in_condition_container(pair: Pair<Rule>) -> TeraResult<Expr> {
     let mut expr = None;
     for p in pair.into_inner() {
         match p.as_rule() {
-            Rule::array => expr = Some(Expr::new(parse_array(p)?)),
+            Rule::array_filter => expr = Some(parse_array_with_filters(p)?),
             Rule::dotted_square_bracket_ident => {
                 expr = Some(Expr::new(ExprVal::Ident(p.as_str().to_string())))
             }
@@ -567,7 +583,7 @@ fn parse_set_tag(pair: Pair<Rule>, global: bool) -> TeraResult<Node> {
             }
             Rule::ident => key = Some(p.as_str().to_string()),
             Rule::logic_expr => expr = Some(parse_logic_expr(p)?),
-            Rule::array => expr = Some(Expr::new(parse_array(p)?)),
+            Rule::array_filter => expr = Some(parse_array_with_filters(p)?),
             _ => unreachable!("unexpected {:?} rule in parse_set_tag", p.as_rule()),
         }
     }
@@ -804,7 +820,7 @@ fn parse_forloop(pair: Pair<Rule>) -> TeraResult<Node> {
                         Rule::basic_expr_filter => {
                             container = Some(parse_basic_expr_with_filters(p2)?);
                         }
-                        Rule::array => container = Some(Expr::new(parse_array(p2)?)),
+                        Rule::array_filter => container = Some(parse_array_with_filters(p2)?),
                         _ => unreachable!(),
                     };
                 }
@@ -1018,6 +1034,7 @@ pub fn parse(input: &str) -> TeraResult<Vec<Node>> {
                     Rule::string_expr_filter => "a string or a concatenation of strings".to_string(),
                     Rule::all_chars => "a character".to_string(),
                     Rule::array => "an array of values".to_string(),
+                    Rule::array_filter => "an array of values with an optional filter".to_string(),
                     Rule::basic_val => "a value".to_string(),
                     Rule::basic_op => "a mathematical operator".to_string(),
                     Rule::comparison_op => "a comparison operator".to_string(),

--- a/src/parser/tera.pest
+++ b/src/parser/tera.pest
@@ -90,20 +90,21 @@ comparison_op   = _{ op_lte | op_gte | op_gt | op_lt | op_eq | op_ineq }
 comparison_expr = { (string_expr_filter | comparison_val) ~ (comparison_op ~ (string_expr_filter | comparison_val))? }
 
 // The `in` operator
-in_cond_container = {string_expr_filter | array | dotted_square_bracket_ident}
+in_cond_container = {string_expr_filter | array_filter | dotted_square_bracket_ident}
 in_cond = !{ (string_expr_filter | basic_expr_filter) ~ op_not? ~ "in" ~ in_cond_container }
 
 logic_val  = !{ op_not? ~ (in_cond | comparison_expr) }
 logic_expr = !{ logic_val ~ ((op_or | op_and) ~ logic_val)* }
 
 array = !{ "[" ~ (logic_val ~ ",")* ~ logic_val? ~ "]"}
+array_filter = !{ array ~ filter* }
 
 // ----------------------------------------------------
 
 /// FUNCTIONS & FILTERS
 
 // A keyword argument: something=10, something="a value", something=1+10 etc
-kwarg   = { ident ~ "=" ~ (logic_expr | array) }
+kwarg   = { ident ~ "=" ~ (logic_expr | array_filter) }
 kwargs  = _{ kwarg ~ ("," ~ kwarg )* }
 fn_call = { ident ~ "(" ~ kwargs? ~ ")" }
 filter  = { "|" ~ (fn_call | ident) }
@@ -127,7 +128,7 @@ macro_call      = { ident ~ "::" ~ ident ~ "(" ~ kwargs? ~ ")" }
 
 // It's a bit weird that tests are the only thing in Tera not using kwargs
 // but at the same time it's one arg most of the time so...
-test_arg  = { logic_expr | array }
+test_arg  = { logic_expr | array_filter }
 test_args = _{ test_arg ~ ("," ~ test_arg)* }
 test_call = !{ ident ~ ("(" ~ test_args ~ ")")? }
 test_not  = { dotted_ident ~ "is" ~ "not" ~ test_call }
@@ -158,7 +159,7 @@ elif_tag         = ${ tag_start ~ WHITESPACE* ~ "elif" ~ WHITESPACE+ ~ logic_exp
 else_tag         = !{ tag_start ~ "else" ~ tag_end }
 for_tag          = ${
     tag_start ~ WHITESPACE*
-    ~ "for"~ WHITESPACE+ ~ ident ~ ("," ~ WHITESPACE* ~ ident)? ~ WHITESPACE+ ~ "in" ~ WHITESPACE+ ~ (basic_expr_filter | array)
+    ~ "for"~ WHITESPACE+ ~ ident ~ ("," ~ WHITESPACE* ~ ident)? ~ WHITESPACE+ ~ "in" ~ WHITESPACE+ ~ (basic_expr_filter | array_filter)
     ~ WHITESPACE* ~ tag_end
 }
 filter_tag       = ${
@@ -168,12 +169,12 @@ filter_tag       = ${
 }
 set_tag          = ${
     tag_start ~ WHITESPACE*
-    ~ "set" ~ WHITESPACE+ ~ ident ~ WHITESPACE* ~ "=" ~ WHITESPACE* ~ (logic_expr | array)
+    ~ "set" ~ WHITESPACE+ ~ ident ~ WHITESPACE* ~ "=" ~ WHITESPACE* ~ (logic_expr | array_filter)
     ~ WHITESPACE* ~ tag_end
 }
 set_global_tag   = ${
     tag_start ~ WHITESPACE*
-    ~ "set_global" ~ WHITESPACE+ ~ ident ~ WHITESPACE* ~ "=" ~ WHITESPACE* ~ (logic_expr | array)
+    ~ "set_global" ~ WHITESPACE+ ~ ident ~ WHITESPACE* ~ "=" ~ WHITESPACE* ~ (logic_expr | array_filter)
     ~ WHITESPACE* ~ tag_end
 }
 endblock_tag     = !{ tag_start ~ "endblock" ~ ident? ~ tag_end }

--- a/src/parser/tera.pest
+++ b/src/parser/tera.pest
@@ -185,7 +185,7 @@ endfilter_tag    = !{ tag_start ~ "endfilter" ~ tag_end }
 break_tag        = !{ tag_start ~ "break" ~ tag_end }
 continue_tag     = !{ tag_start ~ "continue" ~ tag_end }
 
-variable_tag     = !{ variable_start ~ logic_expr ~ variable_end }
+variable_tag     = !{ variable_start ~ (logic_expr | array_filter) ~ variable_end }
 super_tag        = !{ variable_start ~ "super()" ~ variable_end }
 
 text       = ${ (!(block_start) ~ ANY)+ }

--- a/src/parser/tests/parser.rs
+++ b/src/parser/tests/parser.rs
@@ -427,6 +427,33 @@ fn parse_variable_tag_macro_call_with_array() {
         )
     );
 }
+
+// smoke test for array in kwargs
+#[test]
+fn parse_variable_tag_macro_call_with_array_with_filters() {
+    let ast = parse("{{ macros::get_time(some=[1, 2] | reverse) }}").unwrap();
+    let mut args = HashMap::new();
+    args.insert(
+        "some".to_string(),
+        Expr::with_filters(
+            ExprVal::Array(vec![Expr::new(ExprVal::Int(1)), Expr::new(ExprVal::Int(2))]),
+            vec![FunctionCall { name: "reverse".to_string(), args: HashMap::new() },],
+        ),
+    );
+
+    assert_eq!(
+        ast[0],
+        Node::VariableBlock(
+            WS::default(),
+            Expr::new(ExprVal::MacroCall(MacroCall {
+                namespace: "macros".to_string(),
+                name: "get_time".to_string(),
+                args,
+            },))
+        )
+    );
+}
+
 #[test]
 fn parse_variable_tag_macro_call_with_filter() {
     let ast = parse("{{ macros::get_time(some=1) | round }}").unwrap();
@@ -598,6 +625,28 @@ fn parse_set_array() {
                     Expr::new(ExprVal::Bool(true)),
                     Expr::new(ExprVal::String("hello".to_string())),
                 ])),
+                global: false,
+            },
+        )
+    );
+}
+
+#[test]
+fn parse_set_array_with_filter() {
+    let ast = parse("{% set hello = [1, true, 'hello'] | length %}").unwrap();
+    assert_eq!(
+        ast[0],
+        Node::Set(
+            WS::default(),
+            Set {
+                key: "hello".to_string(),
+                value: Expr::with_filters(ExprVal::Array(vec![
+                    Expr::new(ExprVal::Int(1)),
+                    Expr::new(ExprVal::Bool(true)),
+                    Expr::new(ExprVal::String("hello".to_string())),
+                ]),
+                vec![FunctionCall { name: "length".to_string(), args: HashMap::new() },],
+                ),
                 global: false,
             },
         )
@@ -814,6 +863,34 @@ fn parse_value_forloop_array() {
                     Expr::new(ExprVal::Int(1)),
                     Expr::new(ExprVal::Int(2)),
                 ])),
+                body: vec![Node::Text("A".to_string())],
+                empty_body: None,
+            },
+            end_ws,
+        )
+    );
+}
+
+#[test]
+fn parse_value_forloop_array_with_filter() {
+    let ast = parse("{% for item in [1,2,] | reverse %}A{%- endfor %}").unwrap();
+    let start_ws = WS::default();
+    let mut end_ws = WS::default();
+    end_ws.left = true;
+
+    assert_eq!(
+        ast[0],
+        Node::Forloop(
+            start_ws,
+            Forloop {
+                key: None,
+                value: "item".to_string(),
+                container: Expr::with_filters(ExprVal::Array(vec![
+                    Expr::new(ExprVal::Int(1)),
+                    Expr::new(ExprVal::Int(2)),
+                ]),
+                    vec![FunctionCall { name: "reverse".to_string(), args: HashMap::new() },],
+                ),
                 body: vec![Node::Text("A".to_string())],
                 empty_body: None,
             },

--- a/src/parser/tests/parser.rs
+++ b/src/parser/tests/parser.rs
@@ -107,6 +107,41 @@ fn parse_variable_tag_lit() {
 }
 
 #[test]
+fn parse_variable_tag_array_lit() {
+    let ast = parse("{{ [1, 2, 3] }}").unwrap();
+    let mut join_args = HashMap::new();
+    join_args.insert("n".to_string(), Expr::new(ExprVal::Int(2)));
+
+    assert_eq!(
+        ast[0],
+        Node::VariableBlock(
+            WS::default(),
+            Expr::new(
+                ExprVal::Array(vec![Expr::new(ExprVal::Int(1)), Expr::new(ExprVal::Int(2)), Expr::new(ExprVal::Int(3))]),
+            )
+        )
+    );
+}
+
+#[test]
+fn parse_variable_tag_array_lit_with_filter() {
+    let ast = parse("{{ [1, 2, 3] | length }}").unwrap();
+    let mut join_args = HashMap::new();
+    join_args.insert("n".to_string(), Expr::new(ExprVal::Int(2)));
+
+    assert_eq!(
+        ast[0],
+        Node::VariableBlock(
+            WS::default(),
+            Expr::with_filters(
+                ExprVal::Array(vec![Expr::new(ExprVal::Int(1)), Expr::new(ExprVal::Int(2)), Expr::new(ExprVal::Int(3))]),
+                vec![FunctionCall { name: "length".to_string(), args: HashMap::new() },],
+            )
+        )
+    );
+}
+
+#[test]
 fn parse_variable_tag_lit_math_expression() {
     let ast = parse("{{ count + 1 * 2.5 }}").unwrap();
 

--- a/src/renderer/tests/basic.rs
+++ b/src/renderer/tests/basic.rs
@@ -632,6 +632,24 @@ fn filter_filter_works() {
 }
 
 #[test]
+fn filter_on_array_literal_works() {
+    let mut context = Context::new();
+    let i: Option<usize> = None;
+    context.insert("existing", "hello");
+    context.insert("null", &i);
+
+    let inputs = vec![
+        (r#"{% set a = [1, 2, 3] | length %}{{ a }}"#, "3"),
+        (r#"{% for a in [1, 2, 3] | slice(start=1) %}{{ a }}{% endfor %}"#, "23"),
+    ];
+
+    for (input, expected) in inputs {
+        println!("{:?} -> {:?}", input, expected);
+        assert_eq!(render_template(input, &context).unwrap(), expected);
+    }
+}
+
+#[test]
 fn can_do_string_concat() {
     let mut context = Context::new();
     context.insert("a_string", "hello");

--- a/src/renderer/tests/basic.rs
+++ b/src/renderer/tests/basic.rs
@@ -59,6 +59,7 @@ fn render_variable_block_lit_expr() {
         ("{{ true and 10 }}", "true"),
         ("{{ true and not 10 }}", "false"),
         ("{{ not true }}", "false"),
+        ("{{ [1, 2, 3] }}", "[1, 2, 3]"),
     ];
 
     for (input, expected) in inputs {
@@ -639,6 +640,7 @@ fn filter_on_array_literal_works() {
     context.insert("null", &i);
 
     let inputs = vec![
+        (r#"{{ [1, 2, 3] | length }}"#, "3"),
         (r#"{% set a = [1, 2, 3] | length %}{{ a }}"#, "3"),
         (r#"{% for a in [1, 2, 3] | slice(start=1) %}{{ a }}{% endfor %}"#, "23"),
     ];


### PR DESCRIPTION
Hi,
I went ahead and implemented support for filters on array literals even though I wasn't sure if this was considered a bug or not. :slightly_smiling_face: 

I am not sure if I covered every case? I made sure to add some tests on set blocks, for loops and kwargs. I also compiled zola with this patch and made sure that the code snippet [posted on the forum](https://zola.discourse.group/t/can-the-page-title-be-added-to-the-toc/404) was correctly parsed and did the same as the multi-line one.

Let me know if you are interested in this patch and if you want me to change some things or add some more tests.