### PR TITLE
config.toml: Update netlify URL

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -1,6 +1,6 @@
 title = "Tera"
 description = "Tera - A template engine for Rust inspired by Jinja2 and Django templates"
-base_url = "https://tera.netlify.com/"
+base_url = "https://tera.netlify.app/"
 highlight_code = true
 highlight_theme = "monokai"
 compile_sass = true


### PR DESCRIPTION
Netlify has changed their default application URL from a netlify.com domain to netlify.app domain.
Updating the URL here will allow CSS to render correctly on the Tera docs website.