### PR TITLE
feat(filter): add camel and snake filters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,8 @@ chrono-tz = {version = "0.5", optional = true}
 unic-segment = {version = "0.9", optional = true}
 # used in get_random function
 rand = {version = "0.7", optional = true}
+# used in snake_case filter
+heck = { version = "0.3.1", optional = true }
 
 [dev-dependencies]
 serde_derive = "1.0"
@@ -43,7 +45,7 @@ tempfile = "3"
 
 [features]
 default = ["builtins"]
-builtins = ["slug", "percent-encoding", "humansize", "chrono", "chrono-tz", "unic-segment", "rand"]
+builtins = ["slug", "percent-encoding", "humansize", "chrono", "chrono-tz", "unic-segment", "rand", "heck"]
 preserve_order = ["serde_json/preserve_order"]
 
 [badges]

--- a/src/builtins/filters/string.rs
+++ b/src/builtins/filters/string.rs
@@ -418,6 +418,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "builtins")]
     #[test]
     fn test_snake() {
         let result = snake(&to_value("Test Value").unwrap(), &HashMap::new());
@@ -425,6 +426,7 @@ mod tests {
         assert_eq!(result.unwrap(), to_value("test_value").unwrap());
     }
 
+    #[cfg(feature = "builtins")]
     #[test]
     fn test_camel() {
         let result = camel(&to_value("test value").unwrap(), &HashMap::new());

--- a/src/builtins/filters/string.rs
+++ b/src/builtins/filters/string.rs
@@ -80,7 +80,7 @@ pub fn lower(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
 }
 
 #[cfg(feature = "builtins")]
-pub fn snake(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
+pub fn snake_case(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
     use heck::SnakeCase;
     let s = try_get_value!("snake_case", "value", String, value);
 
@@ -88,7 +88,7 @@ pub fn snake(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
 }
 
 #[cfg(feature = "builtins")]
-pub fn camel(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
+pub fn camel_case(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
     use heck::CamelCase;
     let s = try_get_value!("snake_case", "value", String, value);
 
@@ -420,16 +420,16 @@ mod tests {
 
     #[cfg(feature = "builtins")]
     #[test]
-    fn test_snake() {
-        let result = snake(&to_value("Test Value").unwrap(), &HashMap::new());
+    fn test_snake_case() {
+        let result = snake_case(&to_value("Test Value").unwrap(), &HashMap::new());
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), to_value("test_value").unwrap());
     }
 
     #[cfg(feature = "builtins")]
     #[test]
-    fn test_camel() {
-        let result = camel(&to_value("test value").unwrap(), &HashMap::new());
+    fn test_camel_case() {
+        let result = camel_case(&to_value("test value").unwrap(), &HashMap::new());
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), to_value("TestValue").unwrap());
     }

--- a/src/builtins/filters/string.rs
+++ b/src/builtins/filters/string.rs
@@ -79,6 +79,22 @@ pub fn lower(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
     Ok(to_value(&s.to_lowercase()).unwrap())
 }
 
+#[cfg(feature = "builtins")]
+pub fn snake(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
+    use heck::SnakeCase;
+    let s = try_get_value!("snake_case", "value", String, value);
+
+    Ok(to_value(&s.to_snake_case()).unwrap())
+}
+
+#[cfg(feature = "builtins")]
+pub fn camel(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
+    use heck::CamelCase;
+    let s = try_get_value!("snake_case", "value", String, value);
+
+    Ok(to_value(&s.to_camel_case()).unwrap())
+}
+
 /// Strip leading and trailing whitespace.
 pub fn trim(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
     let s = try_get_value!("trim", "value", String, value);
@@ -400,6 +416,20 @@ mod tests {
             result.err().unwrap().to_string(),
             "Filter `upper` was called on an incorrect value: got `50` but expected a String"
         );
+    }
+
+    #[test]
+    fn test_snake() {
+        let result = snake(&to_value("Test Value").unwrap(), &HashMap::new());
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), to_value("test_value").unwrap());
+    }
+
+    #[test]
+    fn test_camel() {
+        let result = camel(&to_value("test value").unwrap(), &HashMap::new());
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), to_value("TestValue").unwrap());
     }
 
     #[test]

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -515,6 +515,8 @@ impl Tera {
     fn register_tera_filters(&mut self) {
         self.register_filter("upper", string::upper);
         self.register_filter("lower", string::lower);
+        self.register_filter("snake", string::snake);
+        self.register_filter("camel", string::camel);
         self.register_filter("trim", string::trim);
         self.register_filter("trim_start", string::trim_start);
         self.register_filter("trim_end", string::trim_end);

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -515,7 +515,9 @@ impl Tera {
     fn register_tera_filters(&mut self) {
         self.register_filter("upper", string::upper);
         self.register_filter("lower", string::lower);
+        #[cfg(feature = "builtins")]
         self.register_filter("snake", string::snake);
+        #[cfg(feature = "builtins")]
         self.register_filter("camel", string::camel);
         self.register_filter("trim", string::trim);
         self.register_filter("trim_start", string::trim_start);

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -516,9 +516,9 @@ impl Tera {
         self.register_filter("upper", string::upper);
         self.register_filter("lower", string::lower);
         #[cfg(feature = "builtins")]
-        self.register_filter("snake", string::snake);
+        self.register_filter("snake", string::snake_case);
         #[cfg(feature = "builtins")]
-        self.register_filter("camel", string::camel);
+        self.register_filter("camel", string::camel_case);
         self.register_filter("trim", string::trim);
         self.register_filter("trim_start", string::trim_start);
         self.register_filter("trim_end", string::trim_end);


### PR DESCRIPTION
This PR adds two more filters for the common text transformations CamelText and snake_text. The implementation relies on `heck`, a text transformation library.