### PR TITLE
Enabled filters & functions to be safe

### DIFF
--- a/src/builtins/filters/mod.rs
+++ b/src/builtins/filters/mod.rs
@@ -13,6 +13,11 @@ pub mod string;
 pub trait Filter: Sync + Send {
     /// The filter function type definition
     fn filter(&self, value: &Value, args: &HashMap<String, Value>) -> Result<Value>;
+
+    /// Whether the current filter's output should be treated as safe, defaults to `false`
+    fn is_safe(&self) -> bool {
+        false
+    }
 }
 
 impl<F> Filter for F

--- a/src/builtins/functions.rs
+++ b/src/builtins/functions.rs
@@ -12,6 +12,11 @@ use crate::errors::{Error, Result};
 pub trait Function: Sync + Send {
     /// The global function type definition
     fn call(&self, args: &HashMap<String, Value>) -> Result<Value>;
+
+    /// Whether the current function's output should be treated as safe, defaults to `false`
+    fn is_safe(&self) -> bool {
+        false
+    }
 }
 
 impl<F> Function for F


### PR DESCRIPTION
Allow external Rust functions and filters to be unescaped. Needed for [docs.rs](https://github.com/Kixiron/docs.rs/blob/features/templates/rustdoc/body.html#L79-L82) and for making more complex rust plugins without having to call `safe` within templates
