### PR TITLE
Allow multiline function kwargs with trailing comma

### DIFF
--- a/src/parser/tera.pest
+++ b/src/parser/tera.pest
@@ -105,7 +105,7 @@ array_filter = !{ array ~ filter* }
 
 // A keyword argument: something=10, something="a value", something=1+10 etc
 kwarg   = { ident ~ "=" ~ (logic_expr | array_filter) }
-kwargs  = _{ kwarg ~ ("," ~ kwarg )* }
+kwargs  = _{ kwarg ~ ("," ~ kwarg )* ~ ","? }
 fn_call = { ident ~ "(" ~ kwargs? ~ ")" }
 filter  = { "|" ~ (fn_call | ident) }
 

--- a/src/parser/tests/lexer.rs
+++ b/src/parser/tests/lexer.rs
@@ -377,6 +377,8 @@ fn lex_fn_call() {
         "fn(hello=1+1,hey=1)",
         "fn(hello1=true,name=name,admin=true)",
         "fn(hello=name)",
+        "fn(hello=name,)",
+        "fn(\n  hello=name,\n)",
         "fn(hello=name|filter,id=1)",
     ];
     for i in inputs {


### PR DESCRIPTION
This patch extends the `kwargs` pest grammar to allow multiline
functions with an optional trailing comma.