### PR TITLE
escape_html: use literal forward slash

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,9 +2,7 @@
 ///
 /// Escape the following characters with HTML entity encoding to prevent switching
 /// into any execution context, such as script, style, or event handlers. Using
-/// hex entities is recommended in the spec. In addition to the 5 characters
-/// significant in XML (&, <, >, ", '), the forward slash is included as it helps
-/// to end an HTML entity.
+/// hex entities is recommended in the spec.
 ///
 /// ```text
 /// & --> &amp;
@@ -12,7 +10,6 @@
 /// > --> &gt;
 /// " --> &quot;
 /// ' --> &#x27;     &apos; is not recommended
-/// / --> &#x2F;     forward slash is included as it helps end an HTML entity
 /// ```
 #[inline]
 pub fn escape_html(input: &str) -> String {
@@ -24,7 +21,6 @@ pub fn escape_html(input: &str) -> String {
             '>' => output.push_str("&gt;"),
             '"' => output.push_str("&quot;"),
             '\'' => output.push_str("&#x27;"),
-            '/' => output.push_str("&#x2F;"),
             _ => output.push(c),
         }
     }


### PR DESCRIPTION
Forward slash is not a reserved HTML character, and most major implementations
do not encode it.

Fixes #567