### PR TITLE
Fix extra memory allocation

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -16,7 +16,7 @@
 /// ```
 #[inline]
 pub fn escape_html(input: &str) -> String {
-    let mut output = String::with_capacity(input.len() * 2);
+    let mut output = String::with_capacity(input.len());
     for c in input.chars() {
         match c {
             '&' => output.push_str("&amp;"),
@@ -41,6 +41,7 @@ mod tests {
     fn test_escape_html() {
         let tests = vec![
             (r"", ""),
+            (r"&&&&&&&&", "&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;"),
             (r"a&b", "a&amp;b"),
             (r"<a", "&lt;a"),
             (r">a", "&gt;a"),


### PR DESCRIPTION
I'm new to rust and could be wrong, but I don't think you need to allocate this much memory.
push_str allocates the 'escaped' characters?

Let me start off by saying I'm only just learning rust. I've been doing what everyone does and wrote a toy blog framework using a bunch of crates and a lot of docs.

This got me into tera. One of my blog posts had deliberately malformed html tags in it just to see what would happen. I was delighted when it was magically escaped. So I went on a hunt to see where the magic lived.

Here we are.

When I read the utility function I kind of scratched my head because you were allocating len * 2 and then potentially requiring much more space than that depending on how many escaped chars there are.

So, I leveraged your test cases, added a test and it failed to fail. Then I figured out how to use your bench tools on rust nightly and they all passed with my change. It seems push_str is doing the memory allocation for us?

So, here's a PR. This is totally a silly case of me being curious. But if my change is indeed bad or would break something, please teach me. As I said, I only just started learning rust.
