### PR TITLE
Implement `useblock` tag to expand blocks multiple times

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -2,7 +2,7 @@
 +++
 
 ```jinja2
-<title>{% block title %}{% endblock title %}</title>
+<title>{% useblock title %}</title>
 <ul>
 {% for user in users -%}
   <li><a href="{{ user.url }}">{{ user.username }}</a></li>

--- a/docs/content/docs/_index.md
+++ b/docs/content/docs/_index.md
@@ -114,7 +114,7 @@ tera.autoescape_on(vec![".php.html"]);
 tera.autoescape_on(vec![]);
 ```
 
-Tera does not perform contextual auto-escaping, eg by parsing the template to know whether to escape JS, CSS or HTML (see 
+Tera does not perform contextual auto-escaping, eg by parsing the template to know whether to escape JS, CSS or HTML (see
 <https://rawgit.com/mikesamuel/sanitized-jquery-templates/trunk/safetemplate.html> for more details on that).
 
 ## Advanced usage
@@ -412,7 +412,7 @@ Filter sections can also contain [`block` sections](@/docs/_index.md#inheritance
 {% filter upper %}
   {% block content_to_be_upper_cased %}
     This will be upper-cased
-  {% endblock content_to_be_upper_cased %} 
+  {% endblock content_to_be_upper_cased %}
 {% endfilter %}
 ```
 
@@ -563,7 +563,7 @@ Lastly, you can set a default body to be rendered when the container is empty:
 {% for product in products %}
   {{loop.index}}. {{product.name}}
 {% else %}
-  No products.  
+  No products.
 {% endfor %}
 ```
 
@@ -644,7 +644,7 @@ Here's an example of a recursive macro:
 {% endmacro factorial %}
 ```
 
-Macros body can contain all normal Tera syntax with the exception of macros definition, `block` and `extends`.
+Macros body can contain all normal Tera syntax with the exception of macros definition, `block`, `useblock` and `extends`.
 
 
 ## Inheritance
@@ -665,11 +665,11 @@ For example, here's a `base.html` almost copied from the Jinja2 documentation:
 <head>
     {% block head %}
     <link rel="stylesheet" href="style.css" />
-    <title>{% block title %}{% endblock title %} - My Webpage</title>
+    <title>{% useblock title %} - My Webpage</title>
     {% endblock head %}
 </head>
 <body>
-    <div id="content">{% block content %}{% endblock content %}</div>
+    <div id="content">{% useblock content %}</div>
     <div id="footer">
         {% block footer %}
         &copy; Copyright 2008 by <a href="http://domain.invalid/">you</a>.
@@ -678,10 +678,15 @@ For example, here's a `base.html` almost copied from the Jinja2 documentation:
 </body>
 </html>
 ```
-The only difference with Jinja2 being that the `endblock` tags have to be named.
+The only two differences to Jinja2 are:
+- `endblock` tags have to be named
+- `{% useblock name %}` may be used instead of `{{ self.name() }}`
 
 This `base.html` template defines 4 `block` tag that child templates can override.
 The `head` and `footer` block have some content already which will be rendered if they are not overridden.
+
+The `useblock` tag simply expands a previously block. This can be used if you want to use a block multiple times.
+If you need to extend a block using `{{/* super() */}}` use `block` instead.
 
 ### Child template
 Again, straight from Jinja2 docs:

--- a/examples/basic/templates/base.html
+++ b/examples/basic/templates/base.html
@@ -12,8 +12,7 @@
 {% endif %}
 {{ "{{ hey }}" }}
 
-{% block content %}
-{% endblock content %}
+{% useblock content %}
 
 {{ macros::hello_world(greeting="世界") }}
 {{ get_random(start=0, end=10) }}

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -337,6 +337,8 @@ pub enum Node {
     FilterSection(WS, FilterSection, WS),
     /// A `{% block name %}...{% endblock %}`
     Block(WS, Block, WS),
+    /// A `{% useblock name %}`
+    UseBlock(WS, String),
     /// A `{% for i in items %}...{% endfor %}`
     Forloop(WS, Forloop, WS),
 

--- a/src/parser/tera.pest
+++ b/src/parser/tera.pest
@@ -185,6 +185,7 @@ endfilter_tag    = !{ tag_start ~ "endfilter" ~ tag_end }
 break_tag        = !{ tag_start ~ "break" ~ tag_end }
 continue_tag     = !{ tag_start ~ "continue" ~ tag_end }
 
+useblock_tag     = ${ tag_start ~ WHITESPACE* ~ "useblock" ~ WHITESPACE+ ~ ident ~ WHITESPACE* ~ tag_end }
 variable_tag     = !{ variable_start ~ (logic_expr | array_filter) ~ variable_end }
 super_tag        = !{ variable_start ~ "super()" ~ variable_end }
 
@@ -215,6 +216,7 @@ filter_section_content = @{
     set_tag |
     set_global_tag |
     block |
+    useblock_tag |
     forloop |
     filter_section_if |
     raw |
@@ -246,6 +248,7 @@ block_content = @{
     set_global_tag |
     block |
     block_if |
+    useblock_tag |
     forloop |
     filter_section |
     raw |
@@ -276,6 +279,7 @@ content = @{
     set_global_tag |
     macro_definition |
     block |
+    useblock_tag |
     content_if |
     forloop |
     filter_section |

--- a/src/parser/tests/errors.rs
+++ b/src/parser/tests/errors.rs
@@ -256,6 +256,16 @@ fn invalid_block_missing_name() {
 }
 
 #[test]
+fn invalid_useblock_missing_name() {
+    assert_err_msg(r#"{% useblock %}"#, &["1:1", "expected an identifier (must start with a-z)"]);
+}
+
+#[test]
+fn invalid_useblock_no_identifier() {
+    assert_err_msg(r#"{% useblock 1 %}"#, &["1:1", "expected an identifier (must start with a-z)"]);
+}
+
+#[test]
 fn unterminated_test() {
     assert_err_msg(
         r#"{% if a is odd( %}"#,

--- a/src/parser/tests/lexer.rs
+++ b/src/parser/tests/lexer.rs
@@ -455,6 +455,11 @@ fn lex_block_tag() {
 }
 
 #[test]
+fn lex_useblock_tag() {
+    assert!(TeraParser::parse(Rule::useblock_tag, "{% useblock my_block %}").is_ok());
+}
+
+#[test]
 fn lex_macro_tag() {
     let inputs =
         vec!["{%- macro tag() %}", "{% macro my_block(name) -%}", "{% macro my_block(name=42) %}"];

--- a/src/parser/tests/parser.rs
+++ b/src/parser/tests/parser.rs
@@ -823,6 +823,12 @@ fn parse_block() {
 }
 
 #[test]
+fn parse_useblock_tag() {
+    let ast = parse("{% useblock my_block -%}").unwrap();
+    assert_eq!(ast[0], Node::UseBlock(WS { left: false, right: true }, "my_block".to_string(),),);
+}
+
+#[test]
 fn parse_simple_macro_definition() {
     let ast = parse("{% macro hello(a=1, b='hello', c) %}A: {{a}}{% endmacro %}").unwrap();
     let mut args = HashMap::new();

--- a/src/parser/whitespace.rs
+++ b/src/parser/whitespace.rs
@@ -54,6 +54,7 @@ pub fn remove_whitespace(nodes: Vec<Node>, body_ws: Option<WS>) -> Vec<Node> {
                 continue;
             }
             Node::VariableBlock(ws, _)
+            | Node::UseBlock(ws, _)
             | Node::ImportMacro(ws, _, _)
             | Node::Extends(ws, _)
             | Node::Include(ws, _)

--- a/src/renderer/tests/errors.rs
+++ b/src/renderer/tests/errors.rs
@@ -282,3 +282,16 @@ fn error_gives_source_on_tests() {
         "Tester `undefined` was called with some args but this test doesn\'t take args"
     );
 }
+
+#[test]
+fn error_on_missing_block_when_using_useblock() {
+    let mut tera = Tera::default();
+    tera.add_raw_templates(vec![("tpl", "{% useblock my_block %}")]).unwrap();
+
+    let result = tera.render("tpl", &Context::new());
+
+    assert_eq!(
+        result.unwrap_err().source().unwrap().to_string(),
+        "Block `my_block` not found while rendering \'tpl\'"
+    );
+}


### PR DESCRIPTION
Hi!

So after using Tera I got to the same problem as discussed in #265, which is to expand a block multiple times. Since a new [`useblock` tag](https://github.com/Keats/tera/issues/265#issuecomment-442858181) was the proposed solution I though I'd implement that. The acutal core changes (136e1e1687fc665163c41cd299387190d2b714cd) aren't very invasive IMHO.

All test cases succeed, so existing users shouldn't be affected in any way due to being a completely new tag.

I added relevant test cases and updated the documentation where appriopriate. I hope that is ok as-is, but I'd be happy to revise it.