### PR TITLE
Bump dependencies to make the crate build with minimal versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,23 +13,23 @@ edition = "2018"
 include = ["src/**/*", "LICENSE", "README.md", "CHANGELOG.md", "!**/tests/*"]
 
 [dependencies]
-globwalk = "0.8"
+globwalk = "0.8.1"
 serde = "1.0"
-serde_json = "1.0"
-pest = "2"
-pest_derive = "2"
+serde_json = "1.0.11"
+pest = "2.0.2"
+pest_derive = "2.0.2"
 lazy_static = "1.0"
 # used in striptags & titles filters. Already pulled by globwalk
 regex = "1.0"
 
 # used in slugify filter
-slug = {version = "0.1", optional = true}
+slug = {version = "0.1.1", optional = true}
 # used in urlencode filter
-percent-encoding = {version = "2", optional = true}
+percent-encoding = {version = "2.1", optional = true}
 # used in filesizeformat filter
 humansize = {version = "1", optional = true}
 # used in date format filter
-chrono = {version = "0.4", optional = true}
+chrono = {version = "0.4.1", optional = true}
 chrono-tz = {version = "0.5", optional = true}
 # used in truncate filter
 unic-segment = {version = "0.9", optional = true}


### PR DESCRIPTION
Some dependencies are too old and does not compile with the minimal versions (generated by `cargo +nightly update -Z minimal-versions`).
This means that the crate can fail to compile even if all dependencies satisfies versions specified by Cargo.toml.

This commit bumps patch versions of dependencies to make the crate build with the minimal versions.
Tested with rustc 1.48.0.

I think this would be non-breaking change since only patch versions are bumped, but I didn't verified that.

## IMPORTANT NOTE
~~This patch makes dependency to globwalk v0.8.1, but it is not released.
I wrote another pull request to fix dependency problems of globwalk v0.8 (<https://github.com/Gilnaa/globwalk/pull/30>).
I don't know the next globwalk release is v0.8.1 or v0.9, but used v0.8.1 since there seems no breaking changes from v0.8 to master.~~

This patch should be merged after the next globwalk is released.