### PR TITLE
Added detailed example for GROUP_BY #571

### DIFF
--- a/docs/content/docs/_index.md
+++ b/docs/content/docs/_index.md
@@ -974,7 +974,27 @@ The `attribute` argument can be used to group posts by year:
 or by author name:
 
 ```jinja2
-{{ posts | group_by(attribute="author.name") }}
+{% for name, author_posts in posts | group_by(attribute="author.name") %}
+    {{ name }}
+    {% for post in author_posts %}
+        {{ post.year }}: {{ post.content }}
+    {% endfor %}
+{% endfor %}
+```
+
+Manipulating the hashmap produced by `group_by` in an arbitrary order requires additional steps to extract the keys into a separate array.
+
+Example:
+
+```jinja2
+{% set map = section.pages | group_by(attribute="year") %}
+{% set_global years = [] %}
+{% for year, ignored in map %}
+    {% set_global years = years | concat(with=year) %}
+{% endfor %}
+{% for year in years | reverse %}
+    {% set posts = map[year] %}
+{% endfor %}
 ```
 
 #### filter


### PR DESCRIPTION
This PR combines an example from #393 with a slightly more detailed example on the basic [GROUP_BY](https://tera.netlify.app/docs/#group-by) usage.

Closes: #571

#### Background

I somehow missed the detail of the current GROUP_BY example and went on a tangent, that lead me to #393 with a good example on how to use GROUP_BY.

It takes a bit more space compared to other built-ins, but I think it will help others understanding how this feature can be used.

#### Caveat

I hope I got the syntax right. I had to modify it slightly from the actual code I used in my project, so this exact version was not tested.