### PR TITLE
Enhance include tag with list and "ignore missing" support

### DIFF
--- a/docs/content/docs/_index.md
+++ b/docs/content/docs/_index.md
@@ -602,6 +602,19 @@ If you want to do that, use macros.
 While you can `set` values in included templates, those values only exist while rendering
 them: the template calling `include` doesn't see them.
 
+You can mark an include with `ignore missing`, so that Tera will ignore the statement if the template to be inclued does not exist.
+
+```jinja2
+{% include "header.html" ignore missing %}
+```
+
+You can also provide a list of templates that are checked for existence before inclusion. The first template that exists will be included. If `ignore missing` is given, it will fall back to rendering nothing if none of the templates exist.
+
+```jinja2
+{% include ["custom/header.html", "header.html"] %}
+{% include ["special_sidebar.html", "sidebar.html"] ignore missing %}
+```
+
 ### Macros
 
 Think of macros as functions or components that you can call and return some text.

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -324,7 +324,7 @@ pub enum Node {
     /// The `{% extends "blabla.html" %}` node, contains the template name
     Extends(WS, String),
     /// The `{% include "blabla.html" %}` node, contains the template name
-    Include(WS, String),
+    Include(WS, Vec<String>),
     /// The `{% import "macros.html" as macros %}`
     ImportMacro(WS, String, String),
     /// The `{% set val = something %}` tag

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -324,7 +324,7 @@ pub enum Node {
     /// The `{% extends "blabla.html" %}` node, contains the template name
     Extends(WS, String),
     /// The `{% include "blabla.html" %}` node, contains the template name
-    Include(WS, Vec<String>),
+    Include(WS, Vec<String>, bool),
     /// The `{% import "macros.html" as macros %}`
     ImportMacro(WS, String, String),
     /// The `{% set val = something %}` tag

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -586,6 +586,7 @@ fn parse_extends(pair: Pair<Rule>) -> TeraResult<Node> {
 fn parse_include(pair: Pair<Rule>) -> TeraResult<Node> {
     let mut ws = WS::default();
     let mut files = vec![];
+    let mut ignore_missing = false;
 
     for p in pair.into_inner() {
         match p.as_rule() {
@@ -596,6 +597,7 @@ fn parse_include(pair: Pair<Rule>) -> TeraResult<Node> {
                 files.push(replace_string_markers(p.as_span().as_str()));
             }
             Rule::string_array => files.extend(parse_string_array(p)?),
+            Rule::ignore_missing => ignore_missing = true,
             Rule::tag_end => {
                 ws.right = p.as_span().as_str() == "-%}";
             }
@@ -603,7 +605,7 @@ fn parse_include(pair: Pair<Rule>) -> TeraResult<Node> {
         };
     }
 
-    Ok(Node::Include(ws, files))
+    Ok(Node::Include(ws, files, ignore_missing))
 }
 
 fn parse_set_tag(pair: Pair<Rule>, global: bool) -> TeraResult<Node> {
@@ -1134,6 +1136,7 @@ pub fn parse(input: &str) -> TeraResult<Vec<Node>> {
                     Rule::raw_text => "some raw text".to_string(),
                     Rule::raw => "a raw block (`{% raw %}...{% endraw %}`".to_string(),
                     Rule::endraw_tag => "`{% endraw %}`".to_string(),
+                    Rule::ignore_missing => "ignore missing mark for include tag".to_string(),
                     Rule::include_tag => r#"an include tag (`{% include "..." %}`)"#.to_string(),
                     Rule::comment_tag => "a comment tag (`{#...#}`)".to_string(),
                     Rule::variable_tag => "a variable tag (`{{ ... }}`)".to_string(),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -480,6 +480,21 @@ fn parse_array(pair: Pair<Rule>) -> TeraResult<ExprVal> {
     Ok(ExprVal::Array(vals))
 }
 
+fn parse_string_array(pair: Pair<Rule>) -> TeraResult<Vec<String>> {
+    let mut vals = vec![];
+
+    for p in pair.into_inner() {
+        match p.as_rule() {
+            Rule::string => {
+                vals.push(replace_string_markers(p.as_span().as_str()));
+            }
+            _ => unreachable!("Got {:?} in parse_string_array", p.as_rule()),
+        }
+    }
+
+    Ok(vals)
+}
+
 fn parse_macro_call(pair: Pair<Rule>) -> TeraResult<MacroCall> {
     let mut namespace = None;
     let mut name = None;
@@ -548,8 +563,7 @@ fn parse_import_macro(pair: Pair<Rule>) -> Node {
     Node::ImportMacro(ws, file.unwrap(), ident.unwrap())
 }
 
-/// `extends` and `include` have the same structure so only way fn to parse them both
-fn parse_extends_include(pair: Pair<Rule>) -> (WS, String) {
+fn parse_extends(pair: Pair<Rule>) -> TeraResult<Node> {
     let mut ws = WS::default();
     let mut file = None;
 
@@ -566,7 +580,30 @@ fn parse_extends_include(pair: Pair<Rule>) -> (WS, String) {
         };
     }
 
-    (ws, file.unwrap())
+    Ok(Node::Extends(ws, file.unwrap()))
+}
+
+fn parse_include(pair: Pair<Rule>) -> TeraResult<Node> {
+    let mut ws = WS::default();
+    let mut files = vec![];
+
+    for p in pair.into_inner() {
+        match p.as_rule() {
+            Rule::tag_start => {
+                ws.left = p.as_span().as_str() == "{%-";
+            }
+            Rule::string => {
+                files.push(replace_string_markers(p.as_span().as_str()));
+            }
+            Rule::string_array => files.extend(parse_string_array(p)?),
+            Rule::tag_end => {
+                ws.right = p.as_span().as_str() == "-%}";
+            }
+            _ => unreachable!(),
+        };
+    }
+
+    Ok(Node::Include(ws, files))
 }
 
 fn parse_set_tag(pair: Pair<Rule>, global: bool) -> TeraResult<Node> {
@@ -986,10 +1023,7 @@ fn parse_content(pair: Pair<Rule>) -> TeraResult<Vec<Node>> {
 
     for p in pair.into_inner() {
         match p.as_rule() {
-            Rule::include_tag => {
-                let (ws, file) = parse_extends_include(p);
-                nodes.push(Node::Include(ws, file));
-            }
+            Rule::include_tag => nodes.push(parse_include(p)?),
             // Ignore comments
             Rule::comment_tag => (),
             Rule::super_tag => nodes.push(Node::Super),
@@ -1036,6 +1070,7 @@ pub fn parse(input: &str) -> TeraResult<Vec<Node>> {
                     Rule::all_chars => "a character".to_string(),
                     Rule::array => "an array of values".to_string(),
                     Rule::array_filter => "an array of values with an optional filter".to_string(),
+                    Rule::string_array => "an array of strings".to_string(),
                     Rule::basic_val => "a value".to_string(),
                     Rule::basic_op => "a mathematical operator".to_string(),
                     Rule::comparison_op => "a comparison operator".to_string(),
@@ -1150,10 +1185,7 @@ pub fn parse(input: &str) -> TeraResult<Vec<Node>> {
     // We must have at least a `template` pair if we got there
     for p in pairs.next().unwrap().into_inner() {
         match p.as_rule() {
-            Rule::extends_tag => {
-                let (ws, file) = parse_extends_include(p);
-                nodes.push(Node::Extends(ws, file));
-            }
+            Rule::extends_tag => nodes.push(parse_extends(p)?),
             Rule::import_macro_tag => nodes.push(parse_import_macro(p)),
             Rule::content => nodes.extend(parse_content(p)?),
             Rule::comment_tag => (),

--- a/src/parser/tera.pest
+++ b/src/parser/tera.pest
@@ -151,8 +151,12 @@ comment_end    = _{ "#}" }
 block_start    = _{ variable_start | tag_start | comment_start }
 
 
+// Tag marks
+ignore_missing = { "ignore" ~ WHITESPACE* ~ "missing" }
+
+
 // Actual tags
-include_tag      = ${ tag_start ~ WHITESPACE* ~ "include" ~ WHITESPACE+ ~ (string | string_array) ~ WHITESPACE* ~ tag_end }
+include_tag      = ${ tag_start ~ WHITESPACE* ~ "include" ~ WHITESPACE+ ~ (string | string_array) ~ WHITESPACE* ~ ignore_missing? ~ WHITESPACE* ~ tag_end }
 comment_tag      = !{ comment_start ~ (!comment_end ~ ANY)* ~ comment_end }
 block_tag        = ${ tag_start ~ WHITESPACE* ~ "block" ~ WHITESPACE+ ~ ident ~ WHITESPACE* ~ tag_end }
 macro_tag        = ${ tag_start ~ WHITESPACE* ~ "macro" ~ WHITESPACE+ ~ macro_fn_wrapper ~ WHITESPACE* ~ tag_end }

--- a/src/parser/tera.pest
+++ b/src/parser/tera.pest
@@ -99,6 +99,8 @@ logic_expr = !{ logic_val ~ ((op_or | op_and) ~ logic_val)* }
 array = !{ "[" ~ (logic_val ~ ",")* ~ logic_val? ~ "]"}
 array_filter = !{ array ~ filter* }
 
+string_array = !{ "[" ~ (string ~ ",")* ~ string? ~ "]"}
+
 // ----------------------------------------------------
 
 /// FUNCTIONS & FILTERS
@@ -150,7 +152,7 @@ block_start    = _{ variable_start | tag_start | comment_start }
 
 
 // Actual tags
-include_tag      = ${ tag_start ~ WHITESPACE* ~ "include" ~ WHITESPACE+ ~ string ~ WHITESPACE* ~ tag_end }
+include_tag      = ${ tag_start ~ WHITESPACE* ~ "include" ~ WHITESPACE+ ~ (string | string_array) ~ WHITESPACE* ~ tag_end }
 comment_tag      = !{ comment_start ~ (!comment_end ~ ANY)* ~ comment_end }
 block_tag        = ${ tag_start ~ WHITESPACE* ~ "block" ~ WHITESPACE+ ~ ident ~ WHITESPACE* ~ tag_end }
 macro_tag        = ${ tag_start ~ WHITESPACE* ~ "macro" ~ WHITESPACE+ ~ macro_fn_wrapper ~ WHITESPACE* ~ tag_end }

--- a/src/parser/tests/lexer.rs
+++ b/src/parser/tests/lexer.rs
@@ -141,6 +141,7 @@ fn lex_array() {
         "[1,2,3]",
         "[1, 2,3,]",
         "[1 + 1, 2,3 * 2,]",
+        "[\"foo\", \"bar\"]",
         "[1,true,'string', 0.5, hello(), macros::hey(arg=1)]",
     ];
 
@@ -428,6 +429,7 @@ fn lex_test() {
 #[test]
 fn lex_include_tag() {
     assert!(TeraParser::parse(Rule::include_tag, "{% include \"index.html\" %}").is_ok());
+    assert!(TeraParser::parse(Rule::include_tag, "{% include [\"index.html\"] %}").is_ok());
 }
 
 #[test]

--- a/src/parser/tests/lexer.rs
+++ b/src/parser/tests/lexer.rs
@@ -430,6 +430,8 @@ fn lex_test() {
 fn lex_include_tag() {
     assert!(TeraParser::parse(Rule::include_tag, "{% include \"index.html\" %}").is_ok());
     assert!(TeraParser::parse(Rule::include_tag, "{% include [\"index.html\"] %}").is_ok());
+    assert!(TeraParser::parse(Rule::include_tag, "{% include [\"index.html\"] ignore missing %}")
+        .is_ok());
 }
 
 #[test]

--- a/src/parser/tests/parser.rs
+++ b/src/parser/tests/parser.rs
@@ -24,7 +24,18 @@ fn parse_text_with_whitespace() {
 #[test]
 fn parse_include_tag() {
     let ast = parse("{% include \"index.html\" -%}").unwrap();
-    assert_eq!(ast[0], Node::Include(WS { left: false, right: true }, "index.html".to_string(),),);
+    assert_eq!(
+        ast[0],
+        Node::Include(WS { left: false, right: true }, vec!["index.html".to_string()],),
+    );
+    let ast = parse("{% include [\"custom/index.html\", \"index.html\"] %}").unwrap();
+    assert_eq!(
+        ast[0],
+        Node::Include(
+            WS { left: false, right: false },
+            vec!["custom/index.html".to_string(), "index.html".to_string()],
+        ),
+    );
 }
 
 #[test]

--- a/src/parser/tests/parser.rs
+++ b/src/parser/tests/parser.rs
@@ -26,14 +26,15 @@ fn parse_include_tag() {
     let ast = parse("{% include \"index.html\" -%}").unwrap();
     assert_eq!(
         ast[0],
-        Node::Include(WS { left: false, right: true }, vec!["index.html".to_string()],),
+        Node::Include(WS { left: false, right: true }, vec!["index.html".to_string()], false,),
     );
-    let ast = parse("{% include [\"custom/index.html\", \"index.html\"] %}").unwrap();
+    let ast = parse("{% include [\"custom/index.html\", \"index.html\"] ignore missing %}").unwrap();
     assert_eq!(
         ast[0],
         Node::Include(
             WS { left: false, right: false },
             vec!["custom/index.html".to_string(), "index.html".to_string()],
+            true,
         ),
     );
 }

--- a/src/parser/whitespace.rs
+++ b/src/parser/whitespace.rs
@@ -56,7 +56,7 @@ pub fn remove_whitespace(nodes: Vec<Node>, body_ws: Option<WS>) -> Vec<Node> {
             Node::VariableBlock(ws, _)
             | Node::ImportMacro(ws, _, _)
             | Node::Extends(ws, _)
-            | Node::Include(ws, _)
+            | Node::Include(ws, _, _)
             | Node::Set(ws, _)
             | Node::Break(ws)
             | Node::Continue(ws) => {

--- a/src/renderer/processor.rs
+++ b/src/renderer/processor.rs
@@ -960,7 +960,7 @@ impl<'a> Processor<'a> {
             }
             Node::Block(_, ref block, _) => buffer.push_str(&self.render_block(block, 0)?),
             Node::Super => buffer.push_str(&self.do_super()?),
-            Node::Include(_, ref tpl_names) => {
+            Node::Include(_, ref tpl_names, ref ignore_missing) => {
                 let mut found = false;
                 for tpl_name in tpl_names {
                     let template = self.tera.get_template(tpl_name);
@@ -976,7 +976,7 @@ impl<'a> Processor<'a> {
                     found = true;
                     break;
                 }
-                if !found {
+                if !found && !ignore_missing {
                     return Err(Error::template_not_found(
                         vec!["[", &tpl_names.join(", ").to_string(), "]"].join(""),
                     ));

--- a/src/renderer/tests/basic.rs
+++ b/src/renderer/tests/basic.rs
@@ -282,6 +282,20 @@ fn render_include_array_tag() {
 }
 
 #[test]
+fn render_include_tag_missing() {
+    let mut tera = Tera::default();
+    tera.add_raw_template("hello", "<h1>Hello {% include \"world\" %}</h1>").unwrap();
+    let result = tera.render("hello", &Context::new());
+    assert!(result.is_err());
+
+    let mut tera = Tera::default();
+    tera.add_raw_template("hello", "<h1>Hello {% include \"world\" ignore missing %}</h1>")
+        .unwrap();
+    let result = tera.render("hello", &Context::new()).unwrap();
+    assert_eq!(result, "<h1>Hello </h1>".to_owned());
+}
+
+#[test]
 fn can_set_variables_in_included_templates() {
     let mut tera = Tera::default();
     tera.add_raw_templates(vec![

--- a/src/renderer/tests/basic.rs
+++ b/src/renderer/tests/basic.rs
@@ -266,6 +266,22 @@ fn render_include_tag() {
 }
 
 #[test]
+fn render_include_array_tag() {
+    let mut tera = Tera::default();
+    tera.add_raw_templates(vec![
+        ("world", "world"),
+        ("hello", "<h1>Hello {% include [\"custom/world\", \"world\"] %}</h1>"),
+    ])
+    .unwrap();
+    let result = tera.render("hello", &Context::new()).unwrap();
+    assert_eq!(result, "<h1>Hello world</h1>".to_owned());
+
+    tera.add_raw_template("custom/world", "custom world").unwrap();
+    let result = tera.render("hello", &Context::new()).unwrap();
+    assert_eq!(result, "<h1>Hello custom world</h1>".to_owned());
+}
+
+#[test]
 fn can_set_variables_in_included_templates() {
     let mut tera = Tera::default();
     tera.add_raw_templates(vec![


### PR DESCRIPTION
Hi! I've added "list of templates" and "ignore missing" support for include tag, so that we can write include tags like below, which have the same syntax as Jinja2 (https://jinja.palletsprojects.com/en/2.11.x/templates/#include).

```jinja
{% include "sidebar.html" ignore missing %}
{% include ['page_detailed.html', 'page.html'] %}
{% include ['special_sidebar.html', 'sidebar.html'] ignore missing %}
```