### PR TITLE
Use std::io::Write to render templates

### DIFF
--- a/src/builtins/filters/array.rs
+++ b/src/builtins/filters/array.rs
@@ -55,8 +55,10 @@ pub fn join(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
     };
 
     // Convert all the values to strings before we join them together.
-    let rendered =
-        arr.iter().map(|v| render_to_string(|w| v.render(w))).collect::<Result<Vec<_>>>()?;
+    let rendered = arr
+        .iter()
+        .map(|v| render_to_string(|| "joining array".to_string(), |w| v.render(w)))
+        .collect::<Result<Vec<_>>>()?;
     to_value(&rendered.join(&sep)).map_err(Error::json)
 }
 

--- a/src/builtins/filters/array.rs
+++ b/src/builtins/filters/array.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use crate::context::{get_json_pointer, ValueRender};
 use crate::errors::{Error, Result};
 use crate::filter_utils::{get_sort_strategy_for_type, get_unique_strategy_for_type};
+use crate::utils::render_to_string;
 use serde_json::value::{to_value, Map, Value};
 
 /// Returns the nth value of an array
@@ -54,7 +55,8 @@ pub fn join(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
     };
 
     // Convert all the values to strings before we join them together.
-    let rendered = arr.iter().map(ValueRender::render).collect::<Vec<_>>();
+    let rendered =
+        arr.iter().map(|v| render_to_string(|w| v.render(w))).collect::<Result<Vec<_>>>()?;
     to_value(&rendered.join(&sep)).map_err(Error::json)
 }
 

--- a/src/builtins/filters/common.rs
+++ b/src/builtins/filters/common.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use std::iter::FromIterator;
 
 use crate::errors::{Error, Result};
+use crate::utils::render_to_string;
 #[cfg(feature = "builtins")]
 use chrono::{
     format::{Item, StrftimeItems},
@@ -142,7 +143,8 @@ pub fn date(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
 
 // Returns the given value as a string.
 pub fn as_str(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
-    to_value(&value.render()).map_err(Error::json)
+    let value = render_to_string(|w| value.render(w))?;
+    to_value(value).map_err(Error::json)
 }
 
 #[cfg(test)]

--- a/src/builtins/filters/common.rs
+++ b/src/builtins/filters/common.rs
@@ -143,7 +143,8 @@ pub fn date(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
 
 // Returns the given value as a string.
 pub fn as_str(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
-    let value = render_to_string(|w| value.render(w))?;
+    let value =
+        render_to_string(|| format!("as_str for value of kind {}", value), |w| value.render(w))?;
     to_value(value).map_err(Error::json)
 }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,5 +1,5 @@
-use std::borrow::Cow;
 use std::collections::BTreeMap;
+use std::io::Write;
 
 use serde::ser::Serialize;
 use serde_json::value::{to_value, Map, Value};
@@ -131,30 +131,31 @@ impl Default for Context {
 }
 
 pub trait ValueRender {
-    fn render(&self) -> Cow<str>;
+    fn render(&self, w: &mut impl Write) -> std::io::Result<()>;
 }
 
 // Convert serde Value to String.
 impl ValueRender for Value {
-    fn render(&self) -> Cow<str> {
+    fn render(&self, w: &mut impl Write) -> std::io::Result<()> {
         match *self {
-            Value::String(ref s) => Cow::Borrowed(s),
-            Value::Number(ref i) => Cow::Owned(i.to_string()),
-            Value::Bool(i) => Cow::Owned(i.to_string()),
-            Value::Null => Cow::Owned(String::new()),
+            Value::String(ref s) => write!(w, "{}", s),
+            Value::Number(ref i) => write!(w, "{}", i),
+            Value::Bool(i) => write!(w, "{}", i),
+            Value::Null => Ok(()),
             Value::Array(ref a) => {
-                let mut buf = String::new();
-                buf.push('[');
+                let mut first = true;
+                write!(w, "[")?;
                 for i in a.iter() {
-                    if buf.len() > 1 {
-                        buf.push_str(", ");
+                    if !first {
+                        write!(w, ", ")?;
                     }
-                    buf.push_str(i.render().as_ref());
+                    first = false;
+                    i.render(w)?;
                 }
-                buf.push(']');
-                Cow::Owned(buf)
+                write!(w, "]")?;
+                Ok(())
             }
-            Value::Object(_) => Cow::Borrowed("[object]"),
+            Value::Object(_) => write!(w, "[object]"),
         }
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -131,31 +131,31 @@ impl Default for Context {
 }
 
 pub trait ValueRender {
-    fn render(&self, w: &mut impl Write) -> std::io::Result<()>;
+    fn render(&self, write: &mut impl Write) -> std::io::Result<()>;
 }
 
 // Convert serde Value to String.
 impl ValueRender for Value {
-    fn render(&self, w: &mut impl Write) -> std::io::Result<()> {
+    fn render(&self, write: &mut impl Write) -> std::io::Result<()> {
         match *self {
-            Value::String(ref s) => write!(w, "{}", s),
-            Value::Number(ref i) => write!(w, "{}", i),
-            Value::Bool(i) => write!(w, "{}", i),
+            Value::String(ref s) => write!(write, "{}", s),
+            Value::Number(ref i) => write!(write, "{}", i),
+            Value::Bool(i) => write!(write, "{}", i),
             Value::Null => Ok(()),
             Value::Array(ref a) => {
                 let mut first = true;
-                write!(w, "[")?;
+                write!(write, "[")?;
                 for i in a.iter() {
                     if !first {
-                        write!(w, ", ")?;
+                        write!(write, ", ")?;
                     }
                     first = false;
-                    i.render(w)?;
+                    i.render(write)?;
                 }
-                write!(w, "]")?;
+                write!(write, "]")?;
                 Ok(())
             }
-            Value::Object(_) => write!(w, "[object]"),
+            Value::Object(_) => write!(write, "[object]"),
         }
     }
 }

--- a/src/filter_utils.rs
+++ b/src/filter_utils.rs
@@ -5,7 +5,6 @@ use std::cmp::Ordering;
 #[derive(PartialEq, PartialOrd, Default, Copy, Clone)]
 pub struct OrderedF64(f64);
 
-
 impl OrderedF64 {
     fn new(n: f64) -> Result<Self> {
         if n.is_finite() {

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -8,10 +8,13 @@ mod macros;
 mod processor;
 mod stack_frame;
 
+use std::io::Write;
+
 use self::processor::Processor;
 use crate::errors::Result;
 use crate::template::Template;
 use crate::tera::Tera;
+use crate::utils::buffer_to_string;
 use crate::Context;
 
 /// Given a `Tera` and reference to `Template` and a `Context`, renders text
@@ -44,15 +47,16 @@ impl<'a> Renderer<'a> {
 
     /// Combines the context with the Template to generate the end result
     pub fn render(&self) -> Result<String> {
-        let output;
+        let mut output = Vec::with_capacity(10_000);
+        self.render_to(&mut output)?;
+        Ok(buffer_to_string(output))
+    }
 
-        {
-            let mut processor =
-                Processor::new(self.template, self.tera, &self.context, self.should_escape);
+    /// Combines the context with the Template to write the end result to output
+    pub fn render_to(&self, mut output: impl Write) -> Result<()> {
+        let mut processor =
+            Processor::new(self.template, self.tera, &self.context, self.should_escape);
 
-            output = processor.render()?;
-        }
-
-        Ok(output)
+        processor.render(&mut output)
     }
 }

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -49,7 +49,7 @@ impl<'a> Renderer<'a> {
     pub fn render(&self) -> Result<String> {
         let mut output = Vec::with_capacity(10_000);
         self.render_to(&mut output)?;
-        Ok(buffer_to_string(output))
+        buffer_to_string(|| "converting rendered buffer to string".to_string(), output)
     }
 
     /// Combines the context with the Template to write the end result to output

--- a/src/renderer/processor.rs
+++ b/src/renderer/processor.rs
@@ -147,9 +147,9 @@ impl<'a> Processor<'a> {
         }
     }
 
-    fn render_body(&mut self, body: &'a [Node], w: &mut impl Write) -> Result<()> {
+    fn render_body(&mut self, body: &'a [Node], write: &mut impl Write) -> Result<()> {
         for n in body {
-            self.render_node(n, w)?;
+            self.render_node(n, write)?;
 
             if self.call_stack.should_break_body() {
                 break;
@@ -159,7 +159,7 @@ impl<'a> Processor<'a> {
         Ok(())
     }
 
-    fn render_for_loop(&mut self, for_loop: &'a Forloop, w: &mut impl Write) -> Result<()> {
+    fn render_for_loop(&mut self, for_loop: &'a Forloop, write: &mut impl Write) -> Result<()> {
         let container_name = match for_loop.container.val {
             ExprVal::Ident(ref ident) => ident,
             ExprVal::FunctionCall(FunctionCall { ref name, .. }) => name,
@@ -214,13 +214,13 @@ impl<'a> Processor<'a> {
 
         let len = for_loop.len();
         match (len, for_loop_empty_body) {
-            (0, Some(empty_body)) => self.render_body(&empty_body, w),
+            (0, Some(empty_body)) => self.render_body(&empty_body, write),
             (0, _) => Ok(()),
             (_, _) => {
                 self.call_stack.push_for_loop_frame(for_loop_name, for_loop);
 
                 for _ in 0..len {
-                    self.render_body(&for_loop_body, w)?;
+                    self.render_body(&for_loop_body, write)?;
 
                     if self.call_stack.should_break_for_loop() {
                         break;
@@ -236,15 +236,15 @@ impl<'a> Processor<'a> {
         }
     }
 
-    fn render_if_node(&mut self, if_node: &'a If, w: &mut impl Write) -> Result<()> {
+    fn render_if_node(&mut self, if_node: &'a If, write: &mut impl Write) -> Result<()> {
         for &(_, ref expr, ref body) in &if_node.conditions {
             if self.eval_as_bool(expr)? {
-                return self.render_body(body, w);
+                return self.render_body(body, write);
             }
         }
 
         if let Some((_, ref body)) = if_node.otherwise {
-            return self.render_body(body, w);
+            return self.render_body(body, write);
         }
 
         Ok(())
@@ -253,7 +253,7 @@ impl<'a> Processor<'a> {
     /// The way inheritance work is that the top parent will be rendered by the renderer so for blocks
     /// we want to look from the bottom (`level = 0`, the template the user is actually rendering)
     /// to the top (the base template).
-    fn render_block(&mut self, block: &'a Block, level: usize, w: &mut impl Write) -> Result<()> {
+    fn render_block(&mut self, block: &'a Block, level: usize, write: &mut impl Write) -> Result<()> {
         let level_template = match level {
             0 => self.call_stack.active_template(),
             _ => self
@@ -268,16 +268,16 @@ impl<'a> Processor<'a> {
         if let Some(block_def) = blocks_definitions.get(&block.name) {
             let (_, Block { ref body, .. }) = block_def[0];
             self.blocks.push((&block.name[..], &level_template.name[..], level));
-            return self.render_body(body, w);
+            return self.render_body(body, write);
         }
 
         // Do we have more parents to look through?
         if level < self.call_stack.active_template().parents.len() {
-            return self.render_block(block, level + 1, w);
+            return self.render_block(block, level + 1, write);
         }
 
         // Nope, just render the body we got
-        self.render_body(&block.body, w)
+        self.render_body(&block.body, write)
     }
 
     fn get_default_value(&mut self, expr: &'a Expr) -> Result<Val<'a>> {
@@ -490,7 +490,7 @@ impl<'a> Processor<'a> {
         Ok(Cow::Owned(tera_fn.call(&args).map_err(err_wrap)?))
     }
 
-    fn eval_macro_call(&mut self, macro_call: &'a MacroCall, w: &mut impl Write) -> Result<()> {
+    fn eval_macro_call(&mut self, macro_call: &'a MacroCall, write: &mut impl Write) -> Result<()> {
         let active_template_name = if let Some(block) = self.blocks.last() {
             block.1
         } else if self.template.name != self.template_root.name {
@@ -531,7 +531,7 @@ impl<'a> Processor<'a> {
             self.tera.get_template(macro_template_name)?,
         );
 
-        self.render_body(&macro_definition.body, w)?;
+        self.render_body(&macro_definition.body, write)?;
 
         self.call_stack.pop();
 
@@ -884,7 +884,7 @@ impl<'a> Processor<'a> {
     /// Only called while rendering a block.
     /// This will look up the block we are currently rendering and its level and try to render
     /// the block at level + n, where would be the next template in the hierarchy the block is present
-    fn do_super(&mut self, w: &mut impl Write) -> Result<()> {
+    fn do_super(&mut self, write: &mut impl Write) -> Result<()> {
         let &(block_name, _, level) = self.blocks.last().unwrap();
         let mut next_level = level + 1;
 
@@ -899,7 +899,7 @@ impl<'a> Processor<'a> {
                 let (ref tpl_name, Block { ref body, .. }) = block_def[0];
                 self.blocks.push((block_name, tpl_name, next_level));
 
-                self.render_body(body, w)?;
+                self.render_body(body, write)?;
                 self.blocks.pop();
 
                 // Can't go any higher for that block anymore?
@@ -934,32 +934,32 @@ impl<'a> Processor<'a> {
 
     /// Process the given node, appending the string result to the buffer
     /// if it is possible
-    fn render_node(&mut self, node: &'a Node, w: &mut impl Write) -> Result<()> {
+    fn render_node(&mut self, node: &'a Node, write: &mut impl Write) -> Result<()> {
         match *node {
-            Node::Text(ref s) | Node::Raw(_, ref s, _) => write!(w, "{}", s)?,
-            Node::VariableBlock(_, ref expr) => self.eval_expression(expr)?.render(w)?,
+            Node::Text(ref s) | Node::Raw(_, ref s, _) => write!(write, "{}", s)?,
+            Node::VariableBlock(_, ref expr) => self.eval_expression(expr)?.render(write)?,
             Node::Set(_, ref set) => self.eval_set(set)?,
             Node::FilterSection(_, FilterSection { ref filter, ref body }, _) => {
                 let body = render_to_string(|w| self.render_body(body, w))?;
-                &self.eval_filter(&Cow::Owned(Value::String(body)), filter, &mut false)?.render(w);
+                &self.eval_filter(&Cow::Owned(Value::String(body)), filter, &mut false)?.render(write);
             }
             // Macros have been imported at the beginning
             Node::ImportMacro(_, _, _) => (),
-            Node::If(ref if_node, _) => self.render_if_node(if_node, w)?,
-            Node::Forloop(_, ref forloop, _) => self.render_for_loop(forloop, w)?,
+            Node::If(ref if_node, _) => self.render_if_node(if_node, write)?,
+            Node::Forloop(_, ref forloop, _) => self.render_for_loop(forloop, write)?,
             Node::Break(_) => {
                 self.call_stack.break_for_loop()?;
             }
             Node::Continue(_) => {
                 self.call_stack.continue_for_loop()?;
             }
-            Node::Block(_, ref block, _) => self.render_block(block, 0, w)?,
-            Node::Super => self.do_super(w)?,
+            Node::Block(_, ref block, _) => self.render_block(block, 0, write)?,
+            Node::Super => self.do_super(write)?,
             Node::Include(_, ref tpl_name) => {
                 let template = self.tera.get_template(tpl_name)?;
                 self.macros.add_macros_from_template(&self.tera, template)?;
                 self.call_stack.push_include_frame(tpl_name, template);
-                self.render_body(&template.ast, w)?;
+                self.render_body(&template.ast, write)?;
                 self.call_stack.pop();
             }
             Node::Extends(_, ref name) => {

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -323,10 +323,10 @@ impl Tera {
     /// context.insert("age", 18);
     /// tera.render_to("hello.html", context, &mut buffer);
     /// ```
-    pub fn render_to(&self, template_name: &str, context: &Context, w: impl Write) -> Result<()> {
+    pub fn render_to(&self, template_name: &str, context: &Context, write: impl Write) -> Result<()> {
         let template = self.get_template(template_name)?;
         let renderer = Renderer::new(template, self, context);
-        renderer.render_to(w)
+        renderer.render_to(write)
     }
 
     /// Renders a one off template (for example a template coming from a user

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -309,6 +309,26 @@ impl Tera {
         renderer.render()
     }
 
+    /// Renders a Tera template given a `tera::Context` to a [std::io::Write],
+    ///
+    /// The only difference from [Self::render] is that this version doesn't convert buffer to a String,
+    /// allowing to render directly to anything that implements [std::io::Write].
+    ///
+    /// Any i/o error will be reported in the result.
+    ///
+    /// ```rust,ignore
+    /// // Rendering a template to an internal buffer
+    /// let mut buffer = Vec::new();
+    /// let mut context = Context::new();
+    /// context.insert("age", 18);
+    /// tera.render_to("hello.html", context, &mut buffer);
+    /// ```
+    pub fn render_to(&self, template_name: &str, context: &Context, w: impl Write) -> Result<()> {
+        let template = self.get_template(template_name)?;
+        let renderer = Renderer::new(template, self, context);
+        renderer.render_to(w)
+    }
+
     /// Renders a one off template (for example a template coming from a user
     /// input) given a `Context` and an instance of Tera. This allows you to
     /// render templates using custom filters or functions.


### PR DESCRIPTION
This allows users to render templates directly to anything that implements std::io::Write (for exemple files).

These changes permits users to control the output buffer when rendering to memory. They should also reduce number of memory allocations, as single rendering steps doesn't return Strings anymore (but instead uses output buffer).

Now the only case where memory really needs to be allocated is when we do not know when the rendered value should really but append to output.
