### PR TITLE
Playground remove wasm-bindgen dev-dependencies

### DIFF
--- a/docs/tera-playground/Cargo.toml
+++ b/docs/tera-playground/Cargo.toml
@@ -30,7 +30,6 @@ serde_json = "1.0.63"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.13"
-wasm-bindgen = { version = "0.2.63", features = ["serde-serialize"] }
 
 [profile.release]
 # Tell `rustc` to optimize for small code size.


### PR DESCRIPTION
I still can't seemed to run the playground with zola

```
Error importing `index.js`: TypeError: WebAssembly: Response has unsupported MIME type '' expected 'application/wasm'
```