### PR TITLE
Allow iteration on a string

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ pest_derive = "2.0.2"
 lazy_static = "1.0"
 # used in striptags & titles filters. Already pulled by globwalk
 regex = "1.0"
+# used in truncate filter and string iteration
+unic-segment = "0.9"
 
 # used in slugify filter
 slug = {version = "0.1.1", optional = true}
@@ -31,8 +33,6 @@ humansize = {version = "1", optional = true}
 # used in date format filter
 chrono = {version = "0.4.1", optional = true}
 chrono-tz = {version = "0.5", optional = true}
-# used in truncate filter
-unic-segment = {version = "0.9", optional = true}
 # used in get_random function
 rand = {version = "0.8", optional = true}
 
@@ -43,7 +43,7 @@ tempfile = "3"
 
 [features]
 default = ["builtins"]
-builtins = ["slug", "percent-encoding", "humansize", "chrono", "chrono-tz", "unic-segment", "rand"]
+builtins = ["slug", "percent-encoding", "humansize", "chrono", "chrono-tz", "rand"]
 preserve_order = ["serde_json/preserve_order"]
 
 [badges]

--- a/docs/content/docs/_index.md
+++ b/docs/content/docs/_index.md
@@ -523,6 +523,19 @@ Loop over items in a array:
   {{loop.index}}. {{product.name}}
 {% endfor %}
 ```
+
+Or on characters of a string:
+
+```jinja2
+{% for letter in name %}
+  {% if loop.index % 2 == 0%}
+    <span style="color:red">{{ letter }}</span>
+  {% else %}
+    <span style="color:blue">{{ letter }}</span>
+  {% endif %}
+{% endfor %}
+```
+
 A few special variables are available inside for loops:
 
 - `loop.index`: current iteration 1-indexed

--- a/src/builtins/filters/string.rs
+++ b/src/builtins/filters/string.rs
@@ -4,11 +4,10 @@ use std::collections::HashMap;
 use lazy_static::lazy_static;
 use regex::{Captures, Regex};
 use serde_json::value::{to_value, Value};
+use unic_segment::GraphemeIndices;
 
 #[cfg(feature = "builtins")]
 use percent_encoding::{percent_encode, AsciiSet, NON_ALPHANUMERIC};
-#[cfg(feature = "builtins")]
-use unic_segment::GraphemeIndices;
 
 use crate::errors::{Error, Result};
 use crate::utils;
@@ -154,7 +153,6 @@ pub fn trim_end_matches(value: &Value, args: &HashMap<String, Value>) -> Result<
 /// The return value of this function might be longer than `length`: the `end`
 /// string is *added* after the truncation occurs.
 ///
-#[cfg(feature = "builtins")]
 pub fn truncate(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
     let s = try_get_value!("truncate", "value", String, value);
     let length = match args.get("length") {
@@ -463,7 +461,6 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "builtins")]
     #[test]
     fn test_truncate_smaller_than_length() {
         let mut args = HashMap::new();
@@ -473,7 +470,6 @@ mod tests {
         assert_eq!(result.unwrap(), to_value("hello").unwrap());
     }
 
-    #[cfg(feature = "builtins")]
     #[test]
     fn test_truncate_when_required() {
         let mut args = HashMap::new();
@@ -483,7 +479,6 @@ mod tests {
         assert_eq!(result.unwrap(), to_value("日本…").unwrap());
     }
 
-    #[cfg(feature = "builtins")]
     #[test]
     fn test_truncate_custom_end() {
         let mut args = HashMap::new();
@@ -494,7 +489,6 @@ mod tests {
         assert_eq!(result.unwrap(), to_value("日本").unwrap());
     }
 
-    #[cfg(feature = "builtins")]
     #[test]
     fn test_truncate_multichar_grapheme() {
         let mut args = HashMap::new();

--- a/src/renderer/for_loop.rs
+++ b/src/renderer/for_loop.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 
 use serde_json::Value;
+use unic_segment::Graphemes;
 
 use crate::renderer::stack_frame::Val;
 
@@ -24,11 +25,13 @@ pub enum ForLoopState {
     Continue,
 }
 
-/// Enumerates on the two types of values to be iterated, scalars and pairs
+/// Enumerates on the types of values to be iterated, scalars and pairs
 #[derive(Debug)]
 pub enum ForLoopValues<'a> {
     /// Values for an array style iteration
     Array(Val<'a>),
+    /// Values for a per-character iteration on a string
+    String(Val<'a>),
     /// Values for an object style iteration
     Object(Vec<(String, Val<'a>)>),
 }
@@ -36,7 +39,9 @@ pub enum ForLoopValues<'a> {
 impl<'a> ForLoopValues<'a> {
     pub fn current_key(&self, i: usize) -> String {
         match *self {
-            ForLoopValues::Array(_) => unreachable!("No key in array list"),
+            ForLoopValues::Array(_) | ForLoopValues::String(_) => {
+                unreachable!("No key in array list or string")
+            }
             ForLoopValues::Object(ref values) => {
                 values.get(i).expect("Failed getting current key").0.clone()
             }
@@ -52,6 +57,10 @@ impl<'a> ForLoopValues<'a> {
                     Cow::Owned(values.as_array().expect("Is array").get(i).expect("Value").clone())
                 }
             },
+            ForLoopValues::String(ref values) => {
+                let mut graphemes = Graphemes::new(values.as_str().expect("Is string"));
+                Cow::Owned(Value::String(graphemes.nth(i).expect("Value").to_string()))
+            }
             ForLoopValues::Object(ref values) => values.get(i).expect("Value").1.clone(),
         }
     }
@@ -83,6 +92,17 @@ impl<'a> ForLoop<'a> {
             value_name: value_name.to_string(),
             current: 0,
             values: ForLoopValues::Array(values),
+            kind: ForLoopKind::Value,
+            state: ForLoopState::Normal,
+        }
+    }
+
+    pub fn from_string(value_name: &str, values: Val<'a>) -> Self {
+        ForLoop {
+            key_name: None,
+            value_name: value_name.to_string(),
+            current: 0,
+            values: ForLoopValues::String(values),
             kind: ForLoopKind::Value,
             state: ForLoopState::Normal,
         }
@@ -175,7 +195,31 @@ impl<'a> ForLoop<'a> {
     pub fn len(&self) -> usize {
         match self.values {
             ForLoopValues::Array(ref values) => values.as_array().expect("Value is array").len(),
+            ForLoopValues::String(ref values) => {
+                values.as_str().expect("Value is string").chars().count()
+            }
             ForLoopValues::Object(ref values) => values.len(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+
+    use serde_json::Value;
+
+    use super::ForLoop;
+
+    #[test]
+    fn test_that_iterating_on_string_yields_grapheme_clusters() {
+        let text = "a\u{310}e\u{301}o\u{308}\u{332}".to_string();
+        let string = Value::String(text.clone());
+        let mut string_loop = ForLoop::from_string("whatever", Cow::Borrowed(&string));
+        assert_eq!(*string_loop.get_current_value(), text[0..3]);
+        string_loop.increment();
+        assert_eq!(*string_loop.get_current_value(), text[3..6]);
+        string_loop.increment();
+        assert_eq!(*string_loop.get_current_value(), text[6..]);
     }
 }

--- a/src/renderer/processor.rs
+++ b/src/renderer/processor.rs
@@ -186,6 +186,15 @@ impl<'a> Processor<'a> {
                 }
                 ForLoop::from_array(&for_loop.value, container_val)
             }
+            Value::String(_) => {
+                if for_loop.key.is_some() {
+                    return Err(Error::msg(format!(
+                        "Tried to iterate using key value on variable `{}`, but it isn't an object/map",
+                        container_name,
+                    )));
+                }
+                ForLoop::from_string(&for_loop.value, container_val)
+            }
             Value::Object(_) => {
                 if for_loop.key.is_none() {
                     return Err(Error::msg(format!(

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -550,7 +550,6 @@ impl Tera {
         self.register_filter("trim_end", string::trim_end);
         self.register_filter("trim_start_matches", string::trim_start_matches);
         self.register_filter("trim_end_matches", string::trim_end_matches);
-        #[cfg(feature = "builtins")]
         self.register_filter("truncate", string::truncate);
         self.register_filter("wordcount", string::wordcount);
         self.register_filter("replace", string::replace);

--- a/tests/render-failures/iterate_on_non_array.html
+++ b/tests/render-failures/iterate_on_non_array.html
@@ -1,3 +1,3 @@
-{% for i in username %}
+{% for i in friend_reviewed %}
 {{i}}
 {% endfor %}

--- a/tests/render_fails.rs
+++ b/tests/render_fails.rs
@@ -77,7 +77,7 @@ fn test_error_render_iterate_non_array() {
     assert_eq!(result.is_err(), true);
     assert_eq!(
         result.unwrap_err().source().unwrap().to_string(),
-        "Tried to iterate on a container (`username`) that has a unsupported type"
+        "Tried to iterate on a container (`friend_reviewed`) that has a unsupported type"
     );
 }
 


### PR DESCRIPTION
I wanted to add some silly per-character rainbow text for my own blog with this style
![image](https://user-images.githubusercontent.com/16676308/113457105-36381f00-940f-11eb-90ca-a8e55fac5206.png)

I managed to do so with `split` but it feels hacky
```jinja2
{%- macro rainbow(text) -%}
{%- set color_index = 0 -%}
{%- set text_length = text | length -%}
{%- set text_array = text | split(pat="") | slice(start=1, end=-1) -%}
{%- for i in range(end=text_length) -%}
    {%- set char = text_array | nth(n=i) -%}
    {%- if char != " " -%}
        <span class="color-{{ color_index % 6 }}">{{ char }}</span>
        {%- set_global color_index = color_index + 1 -%}
    {%- else %} {% endif -%}
{%- endfor -%}
{%- endmacro input -%}
```
Adding the ability to iterate on characters with a filter reduces it to
```jinja2
{%- macro rainbow(text) -%}
{%- set color_index = 0 -%}
{%- for char in text | chars -%}
    {%- if char != " " -%}
        <span class="color-{{ color_index % 6 }}">{{ char }}</span>
        {%- set_global color_index = color_index + 1 -%}
    {%- else %} {% endif -%}
{%- endfor -%}
{%- endmacro input -%}
```

I feel like tera not allowing strings to be iterated on directly was intentional so I chose to implement it as a filter. Using filters also allows for other ways of iterating on a string to be implemented, even though I can't think of another useful way to iterate on a string right now.