### PR TITLE
Fix parsing of filter arguments separated by whitespaces

### DIFF
--- a/src/parser/tera.pest
+++ b/src/parser/tera.pest
@@ -108,7 +108,7 @@ string_array = !{ "[" ~ (string ~ ",")* ~ string? ~ "]"}
 // A keyword argument: something=10, something="a value", something=1+10 etc
 kwarg   = { ident ~ "=" ~ (logic_expr | array_filter) }
 kwargs  = _{ kwarg ~ ("," ~ kwarg )* ~ ","? }
-fn_call = { ident ~ "(" ~ kwargs? ~ ")" }
+fn_call = !{ ident ~ "(" ~ kwargs? ~ ")" }
 filter  = { "|" ~ (fn_call | ident) }
 
 

--- a/src/parser/tests/lexer.rs
+++ b/src/parser/tests/lexer.rs
@@ -468,9 +468,28 @@ fn lex_block_tag() {
 }
 
 #[test]
+fn lex_filter_tag() {
+    let inputs = vec![
+        "{%- filter tag() %}",
+        "{% filter foo(bar=baz) -%}",
+        "{% filter foo(bar=42) %}",
+        "{% filter foo(bar=baz,qux=quz) %}",
+        "{% filter foo(bar=baz, qux=quz) %}",
+        "{% filter foo ( bar=\"baz\", qux=42 ) %}",
+    ];
+    for i in inputs {
+        assert_lex_rule!(Rule::filter_tag, i);
+    }
+}
+
+#[test]
 fn lex_macro_tag() {
-    let inputs =
-        vec!["{%- macro tag() %}", "{% macro my_block(name) -%}", "{% macro my_block(name=42) %}"];
+    let inputs = vec![
+        "{%- macro tag() %}",
+        "{% macro my_block(name) -%}",
+        "{% macro my_block(name=42) %}",
+        "{% macro foo ( bar=\"baz\", qux=42 ) %}",
+    ];
     for i in inputs {
         assert_lex_rule!(Rule::macro_tag, i);
     }


### PR DESCRIPTION
The filter_tag rule is compound atomic, denying implicit whitespaces in
sub-rules such as fn_call. This commit marks fn_call as non-atomic, and
adds filter and macro unit tests for arguments separated by spaces.