### PR TITLE
Missing jinja2 tag in documentation for for-else

### DIFF
--- a/docs/content/docs/_index.md
+++ b/docs/content/docs/_index.md
@@ -559,7 +559,7 @@ You can also iterate on array literals:
 Lastly, you can set a default body to be rendered when the container is empty:
 
 
-```
+```jinja2
 {% for product in products %}
   {{loop.index}}. {{product.name}}
 {% else %}


### PR DESCRIPTION
Causing missing syntax highlighting in the last example here: https://tera.netlify.app/docs/#for