### PR TITLE
Allow dots in context object key names

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -204,7 +204,15 @@ impl ValueTruthy for Value {
 /// Converts a dotted path to a json pointer one
 #[inline]
 pub fn get_json_pointer(key: &str) -> String {
-    ["/", &key.replace(".", "/")].join("")
+    lazy_static::lazy_static! {
+        // Split the key into dot-separated segments, respecting quoted strings as single units
+        // to fix https://github.com/Keats/tera/issues/590
+        static ref JSON_POINTER_REGEX: regex::Regex = regex::Regex::new("\"[^\"]*\"|[^.]+").unwrap();
+    }
+
+    let mut segments = vec![""];
+    segments.extend(JSON_POINTER_REGEX.find_iter(key).map(|mat| mat.as_str().trim_matches('"')));
+    segments.join("/")
 }
 
 #[cfg(test)]

--- a/src/renderer/processor.rs
+++ b/src/renderer/processor.rs
@@ -63,11 +63,11 @@ fn evaluate_sub_variables<'a>(key: &str, call_stack: &CallStack<'a>) -> Result<S
 
     Ok(new_key
         .replace("/", "~1") // https://tools.ietf.org/html/rfc6901#section-3
-        .replace("['", ".")
-        .replace("[\"", ".")
+        .replace("['", ".\"")
+        .replace("[\"", ".\"")
         .replace("[", ".")
-        .replace("']", "")
-        .replace("\"]", "")
+        .replace("']", "\"")
+        .replace("\"]", "\"")
         .replace("]", ""))
 }
 

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -956,8 +956,8 @@ mod tests {
         let mut my_tera = Tera::default();
         my_tera
             .add_raw_templates(vec![
-                ("dots", "{{ map[\"a.b.c\"] }}"),
-                ("urls", "{{ map[\"https://example.com\"] }}"),
+                ("dots", r#"{{ map["a.b.c"] }}"#),
+                ("urls", r#"{{ map["https://example.com"] }}"#),
             ])
             .unwrap();
 

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -952,6 +952,27 @@ mod tests {
     }
 
     #[test]
+    fn test_render_map_with_dotted_keys() {
+        let mut my_tera = Tera::default();
+        my_tera
+            .add_raw_templates(vec![
+                ("dots", "{{ map[\"a.b.c\"] }}"),
+                ("urls", "{{ map[\"https://example.com\"] }}"),
+            ])
+            .unwrap();
+
+        let mut map = HashMap::new();
+        map.insert("a.b.c", "success");
+        map.insert("https://example.com", "success");
+
+        let mut tera_context = Context::new();
+        tera_context.insert("map", &map);
+
+        my_tera.render("dots", &tera_context).unwrap();
+        my_tera.render("urls", &tera_context).unwrap();
+    }
+
+    #[test]
     fn test_extend_no_overlap() {
         let mut my_tera = Tera::default();
         my_tera


### PR DESCRIPTION
See: #590

To summarize the change, I'll compare the indexing flow from before to now:

Before:
`{{ map["a.b"] }}` would be turned into a 'key' `map.a.b` which would then get translated into json pointer notation `map/a/b`and then used to retrieve the value.

Now:
`{{ map["a.b"] }}` is turned into the key `map."a.b"` which then gets translated into json pointer notation, respecting quoted strings as a single path segment `map/a.b`