### PR TITLE
Add linebreaksbr builtin

### DIFF
--- a/docs/content/docs/_index.md
+++ b/docs/content/docs/_index.md
@@ -833,6 +833,16 @@ By default, the filter will add an ellipsis at the end if the text was truncated
 change the string appended by setting the `end` argument.
 For example, `{{ value | truncate(length=10, end="") }}` will not append anything.
 
+#### linebreaksbr
+Replaces line breaks (`\n` or `\r\n`) with HTML line breaks (`<br>`).
+
+Example: `{{ value | linebreaksbr }}`
+
+If value is "Hello\r\nworld\n", the output will be "Hello&lt;br&gt;world&lt;br&gt;".
+
+Note that if the template you using it in is automatically escaped, you will
+need to call the `safe` filter before `linebreaksbr`.
+
 #### striptags
 Tries to remove HTML tags from input. Does not guarantee well formed output if input is not valid HTML.
 

--- a/src/builtins/filters/string.rs
+++ b/src/builtins/filters/string.rs
@@ -255,6 +255,14 @@ pub fn title(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
     .unwrap())
 }
 
+/// Convert line breaks (`\n` or `\r\n`) to HTML linebreaks (`<br>`).
+///
+/// Example: The input "Hello\nWorld" turns into "Hello<br>World".
+pub fn linebreaksbr(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
+    let s = try_get_value!("title", "value", String, value);
+    Ok(to_value(&s.replace("\r\n", "<br>").replace("\n", "<br>")).unwrap())
+}
+
 /// Removes html tags from string
 pub fn striptags(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
     let s = try_get_value!("striptags", "value", String, value);
@@ -818,5 +826,23 @@ mod tests {
         let result = float(&to_value(1.23).unwrap(), &args);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), to_value(1.23).unwrap());
+    }
+
+    #[test]
+    fn test_linebreaksbr() {
+        let args = HashMap::new();
+        let tests: Vec<(&str, &str)> = vec![
+            ("hello world", "hello world"),
+            ("hello\nworld", "hello<br>world"),
+            ("hello\r\nworld", "hello<br>world"),
+            ("hello\n\rworld", "hello<br>\rworld"),
+            ("hello\r\n\nworld", "hello<br><br>world"),
+            ("hello<br>world\n", "hello<br>world<br>"),
+        ];
+        for (input, expected) in tests {
+            let result = linebreaksbr(&to_value(input).unwrap(), &args);
+            assert!(result.is_ok());
+            assert_eq!(result.unwrap(), to_value(expected).unwrap());
+        }
     }
 }

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -556,6 +556,7 @@ impl Tera {
         self.register_filter("replace", string::replace);
         self.register_filter("capitalize", string::capitalize);
         self.register_filter("title", string::title);
+        self.register_filter("linebreaksbr", string::linebreaksbr);
         self.register_filter("striptags", string::striptags);
         #[cfg(feature = "builtins")]
         self.register_filter("urlencode", string::urlencode);


### PR DESCRIPTION
The name is taken from Django, where the same built-in template filter exists.

Adresses #435.