### PR TITLE
Cargo: only include files from workspace root

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/Keats/tera"
 keywords = ["template", "html", "django", "markup", "jinja2"]
 categories = ["template-engine"]
 edition = "2018"
-include = ["src/**/*", "LICENSE", "README.md", "CHANGELOG.md"]
+include = ["/src/**/*", "/LICENSE", "/README.md", "/CHANGELOG.md"]
 
 [dependencies]
 globwalk = "0.8.1"


### PR DESCRIPTION
In the crate published to crates.io, almost 1000 files from bundled node modules are included because they match the "include" rule in Cargo.toml. With this PR, only the LICENSE, README and CHANGELOG from the root of the repository are included (which I assume is the intention), and the almost 1000 license and readme files from node modules are excluded.

You can verify that the published crates contain node module gunk right now by running "cargo package" locally and inspecting the `target/package/` directory contents.