### PR TITLE
Don't enable oldtime feature of chrono

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ percent-encoding = {version = "2.1", optional = true}
 # used in filesizeformat filter
 humansize = {version = "1", optional = true}
 # used in date format filter
-chrono = {version = "0.4.1", optional = true}
+chrono = {version = "0.4.1", optional = true, default-features = false}
 chrono-tz = {version = "0.5", optional = true}
 # used in get_random function
 rand = {version = "0.8", optional = true}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ percent-encoding = {version = "2.1", optional = true}
 # used in filesizeformat filter
 humansize = {version = "1", optional = true}
 # used in date format filter
-chrono = {version = "0.4.1", optional = true, default-features = false}
+chrono = {version = "0.4.1", optional = true, default-features = false, features = ["std", "clock"]}
 chrono-tz = {version = "0.5", optional = true}
 # used in get_random function
 rand = {version = "0.8", optional = true}


### PR DESCRIPTION
Chrono has a default feature `oldtime` that pulls in an outdated crate. `tera` is not using it, so it doesn't need to enable it.