### PR TITLE
Speed up get_json_pointer

### DIFF
--- a/benches/json_pointer.rs
+++ b/benches/json_pointer.rs
@@ -1,0 +1,13 @@
+#![feature(test)]
+extern crate tera;
+extern crate test;
+
+#[bench]
+fn bench_get_json_pointer(b: &mut test::Bencher) {
+    b.iter(|| tera::get_json_pointer("foo.bar.baz"))
+}
+
+#[bench]
+fn bench_get_json_pointer_with_map(b: &mut test::Bencher) {
+    b.iter(|| tera::get_json_pointer("foo[\"http://example.com/\"].bar.baz"))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,12 +22,14 @@ mod utils;
 
 // Library exports.
 
-// Template is meant to be used internally only but is exported for test/bench.
 pub use crate::builtins::filters::Filter;
 pub use crate::builtins::functions::Function;
 pub use crate::builtins::testers::Test;
 pub use crate::context::Context;
 pub use crate::errors::{Error, ErrorKind, Result};
+// Template and get_json_pointer are meant to be used internally only but is exported for test/bench.
+#[doc(hidden)]
+pub use crate::context::get_json_pointer;
 #[doc(hidden)]
 pub use crate::template::Template;
 pub use crate::tera::Tera;


### PR DESCRIPTION
The regex only needs to get called when there's a double quote somewhere
in the input.

Benchmarks below are for the two cases: When there's no double quote, we
skip the regex and go fast. When there is a double quote, we run the
regex and go slow.

test bench_get_json_pointer          ... bench:  96 ns/iter (+/- 1)
test bench_get_json_pointer_with_map ... bench: 518 ns/iter (+/- 18)

The regex calls showed up in [profiling of rustdoc](https://github.com/rust-lang/rust/issues/89732#issuecomment-941505294).