### PR TITLE
Add Sync + Send to FunctionRelaxed

### DIFF
--- a/src/builtins/functions.rs
+++ b/src/builtins/functions.rs
@@ -9,7 +9,7 @@ use serde_json::value::{from_value, to_value, Value};
 use crate::errors::{Error, Result};
 
 /// The context-local function type definition
-pub trait FunctionRelaxed {
+pub trait FunctionRelaxed: Sync + Send  {
     /// The context-local function type definition
     fn call(&self, args: &HashMap<String, Value>) -> Result<Value>;
 
@@ -21,7 +21,7 @@ pub trait FunctionRelaxed {
 
 impl<F> FunctionRelaxed for F
 where
-    F: Fn(&HashMap<String, Value>) -> Result<Value>,
+    F: Fn(&HashMap<String, Value>) -> Result<Value> + Sync + Send,
 {
     fn call(&self, args: &HashMap<String, Value>) -> Result<Value> {
         self(args)


### PR DESCRIPTION
34435db introduced `cannot be sent between threads safely` error.

**Disclaimer** I have no idea what I am doing, feel free to disregard this PR.

I've noticed a regression when upgrading to tera 1.13.0. The error was:

```
`(dyn FunctionRelaxed + 'static)` cannot be sent between threads safely
```

After some digging I identified 34435db responsible for the regression. Following the compiler advises, I've managed to "fix" the issue (as in, the code build and the tests are green)

Again, I'm still new to Rust and I haven't looked at what the code I modified do. So handle with care, I guess.

Might be related to  #458 