### PR TITLE
add case-sensitive arg to sort filter

### DIFF
--- a/docs/content/docs/_index.md
+++ b/docs/content/docs/_index.md
@@ -919,6 +919,8 @@ The values in the array must be a sortable type:
 If you need to sort a list of structs or tuples, use the `attribute`
 argument to specify which field to sort by.
 
+Sorting is case-sensitive by default. If you need to sort an array of strings case-insensitively, use the `case-sensitive` argument (set it to false.)
+
 Example:
 
 Given `people` is an array of Person
@@ -942,6 +944,12 @@ or by age:
 
 ```jinja2
 {{ people | sort(attribute="age") }}
+```
+
+The `case-sensitive` argument can be used to sort case-insensitively:
+
+```jinja2
+{{ people | sort(attribute="name.0", case_sensitive=false) }}
 ```
 
 #### unique

--- a/src/filter_utils.rs
+++ b/src/filter_utils.rs
@@ -24,6 +24,9 @@ impl Ord for OrderedF64 {
     }
 }
 
+#[derive(PartialEq, PartialOrd, Default, Clone, Ord, Eq)]
+pub struct CaseInsensitiveString(String);
+
 #[derive(Default, Eq, PartialEq, Ord, PartialOrd, Copy, Clone)]
 pub struct ArrayLen(usize);
 
@@ -58,6 +61,19 @@ impl GetValue for String {
     }
 }
 
+impl From<String> for CaseInsensitiveString {
+    fn from(s: String) -> CaseInsensitiveString {
+        CaseInsensitiveString(s)
+    }
+}
+
+impl GetValue for CaseInsensitiveString {
+    fn get_value(val: &Value) -> Result<Self> {
+        let s = val.as_str().ok_or_else(|| Error::msg(format!("expected string, got {}", val)));
+        Ok(CaseInsensitiveString::from(s?.to_lowercase()))
+    }
+}
+
 impl GetValue for ArrayLen {
     fn get_value(val: &Value) -> Result<Self> {
         let arr =
@@ -75,6 +91,7 @@ type SortNumbers = SortPairs<OrderedF64>;
 type SortBools = SortPairs<bool>;
 type SortStrings = SortPairs<String>;
 type SortArrays = SortPairs<ArrayLen>;
+pub(crate) type SortStringsCaseInsensitive = SortPairs<CaseInsensitiveString>;
 
 impl<K: GetValue> SortPairs<K> {
     fn try_add_pair(&mut self, val: &Value, key: &Value) -> Result<()> {


### PR DESCRIPTION
This PR will fix #587 if merged.

I'm very new to Rust programming, my apologies if I've done something wrong here.
I've added a case_sensitive argument that when set to false will make the sorting case insensitive. Here's the code I used to test it.
```rs
use serde::{Deserialize, Serialize};
use tera::{Context, Tera};

#[derive(Deserialize, Serialize, Debug, Clone)]
struct Person {
    name: String,
}

fn main() -> Result<(), tera::Error> {
    // Use globbing
    let tera = match Tera::new("templates/**/*.html") {
        Ok(t) => t,
        Err(e) => {
            println!("Parsing error(s): {}", e);
            ::std::process::exit(1);
        }
    };

    let persons: Vec<Person> = vec![
        Person { name: "Robert".into(), },
        Person { name: "paul".into(), },
    ];

    let mut ctx = Context::new();
    ctx.try_insert("persons", &persons)?;

    println!("{}", tera.render("foo.html", &ctx)?);

    Ok(())
}
```

With the following template
```html
<div>
    {% for person in persons | sort(attribute="name") %}
    <div>
        {{person.name}}
    </div>
    {%endfor%}
</div>
```
The output is
```html
<div>
    
    <div>
        Robert
    </div>
    
    <div>
        paul
    </div>
    
</div>
```

With case_sensitive=false
```html
<div>
    {% for person in persons | sort(case_sensitive=false, attribute="name") %}
    <div>
        {{person.name}}
    </div>
    {%endfor%}
</div>
```

The output becomes:
```html
<div>
    
    <div>
        paul
    </div>
    
    <div>
        Robert
    </div>
    
</div>
```

Please let me know if there's anything else I need to do before this can be merged.