### PR TITLE
Fix HTML file extension in auto-escaping example

### DIFF
--- a/docs/content/docs/_index.md
+++ b/docs/content/docs/_index.md
@@ -72,7 +72,7 @@ lazy_static! {
                 ::std::process::exit(1);
             }
         };
-        tera.autoescape_on(vec!["html", ".sql"]);
+        tera.autoescape_on(vec![".html", ".sql"]);
         tera.register_filter("do_nothing", do_nothing_filter);
         tera
     };


### PR DESCRIPTION
Not sure if it would still apply to files ending in `.html`, but for consistency if not for safety let's be exact here (and avoid confusion).