### PR TITLE
Add feature for just the urlencode builtin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,8 @@ tempfile = "3"
 
 [features]
 default = ["builtins"]
-builtins = ["builtins_urlencode", "slug", "humansize", "chrono", "chrono-tz", "rand"]
-builtins_urlencode = ["percent-encoding"]
+builtins = ["urlencode", "slug", "humansize", "chrono", "chrono-tz", "rand"]
+urlencode = ["percent-encoding"]
 preserve_order = ["serde_json/preserve_order"]
 
 [badges]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,8 @@ tempfile = "3"
 
 [features]
 default = ["builtins"]
-builtins = ["slug", "percent-encoding", "humansize", "chrono", "chrono-tz", "rand"]
+builtins = ["builtins_urlencode", "slug", "humansize", "chrono", "chrono-tz", "rand"]
+builtins_urlencode = ["percent-encoding"]
 preserve_order = ["serde_json/preserve_order"]
 
 [badges]

--- a/src/builtins/filters/string.rs
+++ b/src/builtins/filters/string.rs
@@ -6,23 +6,23 @@ use regex::{Captures, Regex};
 use serde_json::value::{to_value, Value};
 use unic_segment::GraphemeIndices;
 
-#[cfg(feature = "builtins")]
+#[cfg(feature = "builtins_urlencode")]
 use percent_encoding::{percent_encode, AsciiSet, NON_ALPHANUMERIC};
 
 use crate::errors::{Error, Result};
 use crate::utils;
 
 /// https://url.spec.whatwg.org/#fragment-percent-encode-set
-#[cfg(feature = "builtins")]
+#[cfg(feature = "builtins_urlencode")]
 const FRAGMENT_ENCODE_SET: &AsciiSet =
     &percent_encoding::CONTROLS.add(b' ').add(b'"').add(b'<').add(b'>').add(b'`');
 
 /// https://url.spec.whatwg.org/#path-percent-encode-set
-#[cfg(feature = "builtins")]
+#[cfg(feature = "builtins_urlencode")]
 const PATH_ENCODE_SET: &AsciiSet = &FRAGMENT_ENCODE_SET.add(b'#').add(b'?').add(b'{').add(b'}');
 
 /// https://url.spec.whatwg.org/#userinfo-percent-encode-set
-#[cfg(feature = "builtins")]
+#[cfg(feature = "builtins_urlencode")]
 const USERINFO_ENCODE_SET: &AsciiSet = &PATH_ENCODE_SET
     .add(b'/')
     .add(b':')
@@ -38,7 +38,7 @@ const USERINFO_ENCODE_SET: &AsciiSet = &PATH_ENCODE_SET
 /// Same as Python quote
 /// https://github.com/python/cpython/blob/da27d9b9dc44913ffee8f28d9638985eaaa03755/Lib/urllib/parse.py#L787
 /// with `/` not escaped
-#[cfg(feature = "builtins")]
+#[cfg(feature = "builtins_urlencode")]
 const PYTHON_ENCODE_SET: &AsciiSet = &USERINFO_ENCODE_SET
     .remove(b'/')
     .add(b':')
@@ -214,7 +214,7 @@ pub fn capitalize(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
 }
 
 /// Percent-encodes reserved URI characters
-#[cfg(feature = "builtins")]
+#[cfg(feature = "builtins_urlencode")]
 pub fn urlencode(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
     let s = try_get_value!("urlencode", "value", String, value);
     let encoded = percent_encode(s.as_bytes(), &PYTHON_ENCODE_SET).to_string();
@@ -222,7 +222,7 @@ pub fn urlencode(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
 }
 
 /// Percent-encodes all non-alphanumeric characters
-#[cfg(feature = "builtins")]
+#[cfg(feature = "builtins_urlencode")]
 pub fn urlencode_strict(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
     let s = try_get_value!("urlencode_strict", "value", String, value);
     let encoded = percent_encode(s.as_bytes(), &NON_ALPHANUMERIC).to_string();
@@ -596,7 +596,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "builtins")]
+    #[cfg(feature = "builtins_urlencode")]
     #[test]
     fn test_urlencode() {
         let tests = vec![
@@ -620,7 +620,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "builtins")]
+    #[cfg(feature = "builtins_urlencode")]
     #[test]
     fn test_urlencode_strict() {
         let tests = vec![

--- a/src/builtins/filters/string.rs
+++ b/src/builtins/filters/string.rs
@@ -6,23 +6,23 @@ use regex::{Captures, Regex};
 use serde_json::value::{to_value, Value};
 use unic_segment::GraphemeIndices;
 
-#[cfg(feature = "builtins_urlencode")]
+#[cfg(feature = "urlencode")]
 use percent_encoding::{percent_encode, AsciiSet, NON_ALPHANUMERIC};
 
 use crate::errors::{Error, Result};
 use crate::utils;
 
 /// https://url.spec.whatwg.org/#fragment-percent-encode-set
-#[cfg(feature = "builtins_urlencode")]
+#[cfg(feature = "urlencode")]
 const FRAGMENT_ENCODE_SET: &AsciiSet =
     &percent_encoding::CONTROLS.add(b' ').add(b'"').add(b'<').add(b'>').add(b'`');
 
 /// https://url.spec.whatwg.org/#path-percent-encode-set
-#[cfg(feature = "builtins_urlencode")]
+#[cfg(feature = "urlencode")]
 const PATH_ENCODE_SET: &AsciiSet = &FRAGMENT_ENCODE_SET.add(b'#').add(b'?').add(b'{').add(b'}');
 
 /// https://url.spec.whatwg.org/#userinfo-percent-encode-set
-#[cfg(feature = "builtins_urlencode")]
+#[cfg(feature = "urlencode")]
 const USERINFO_ENCODE_SET: &AsciiSet = &PATH_ENCODE_SET
     .add(b'/')
     .add(b':')
@@ -38,7 +38,7 @@ const USERINFO_ENCODE_SET: &AsciiSet = &PATH_ENCODE_SET
 /// Same as Python quote
 /// https://github.com/python/cpython/blob/da27d9b9dc44913ffee8f28d9638985eaaa03755/Lib/urllib/parse.py#L787
 /// with `/` not escaped
-#[cfg(feature = "builtins_urlencode")]
+#[cfg(feature = "urlencode")]
 const PYTHON_ENCODE_SET: &AsciiSet = &USERINFO_ENCODE_SET
     .remove(b'/')
     .add(b':')
@@ -214,7 +214,7 @@ pub fn capitalize(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
 }
 
 /// Percent-encodes reserved URI characters
-#[cfg(feature = "builtins_urlencode")]
+#[cfg(feature = "urlencode")]
 pub fn urlencode(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
     let s = try_get_value!("urlencode", "value", String, value);
     let encoded = percent_encode(s.as_bytes(), &PYTHON_ENCODE_SET).to_string();
@@ -222,7 +222,7 @@ pub fn urlencode(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
 }
 
 /// Percent-encodes all non-alphanumeric characters
-#[cfg(feature = "builtins_urlencode")]
+#[cfg(feature = "urlencode")]
 pub fn urlencode_strict(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
     let s = try_get_value!("urlencode_strict", "value", String, value);
     let encoded = percent_encode(s.as_bytes(), &NON_ALPHANUMERIC).to_string();
@@ -596,7 +596,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "builtins_urlencode")]
+    #[cfg(feature = "urlencode")]
     #[test]
     fn test_urlencode() {
         let tests = vec![
@@ -620,7 +620,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "builtins_urlencode")]
+    #[cfg(feature = "urlencode")]
     #[test]
     fn test_urlencode_strict() {
         let tests = vec![

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -580,9 +580,9 @@ impl Tera {
         self.register_filter("linebreaksbr", string::linebreaksbr);
         self.register_filter("striptags", string::striptags);
         self.register_filter("spaceless", string::spaceless);
-        #[cfg(feature = "builtins_urlencode")]
+        #[cfg(feature = "urlencode")]
         self.register_filter("urlencode", string::urlencode);
-        #[cfg(feature = "builtins_urlencode")]
+        #[cfg(feature = "urlencode")]
         self.register_filter("urlencode_strict", string::urlencode_strict);
         self.register_filter("escape", string::escape_html);
         self.register_filter("escape_xml", string::escape_xml);

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -580,9 +580,9 @@ impl Tera {
         self.register_filter("linebreaksbr", string::linebreaksbr);
         self.register_filter("striptags", string::striptags);
         self.register_filter("spaceless", string::spaceless);
-        #[cfg(feature = "builtins")]
+        #[cfg(feature = "builtins_urlencode")]
         self.register_filter("urlencode", string::urlencode);
-        #[cfg(feature = "builtins")]
+        #[cfg(feature = "builtins_urlencode")]
         self.register_filter("urlencode_strict", string::urlencode_strict);
         self.register_filter("escape", string::escape_html);
         self.register_filter("escape_xml", string::escape_xml);


### PR DESCRIPTION
This way, I don't have to pull in a bunch of other dependencies that I don't need, but can still have the urlencode filter which I do need.