### PR TITLE
Support supplying a timezone for timestamps

### DIFF
--- a/docs/content/docs/_index.md
+++ b/docs/content/docs/_index.md
@@ -1189,7 +1189,7 @@ on [chrono docs](https://docs.rs/chrono/0.4/chrono/format/strftime/index.html).
 
 Example: `{{ ts | date }} {{ ts | date(format="%Y-%m-%d %H:%M") }}`
 
-If you are using ISO 8601 date strings you can optionally supply a timezone for the date to be rendered in.
+If you are using ISO 8601 date strings or a UTC timestamp, you can optionally supply a timezone for the date to be rendered in.
 
 Example:
 
@@ -1197,6 +1197,8 @@ Example:
 {{ "2019-09-19T13:18:48.731Z" | date(timezone="America/New_York") }}
 
 {{ "2019-09-19T13:18:48.731Z" | date(format="%Y-%m-%d %H:%M", timezone="Asia/Shanghai") }}
+
+{{ 1648252203 | date(timezone="Europe/Berlin") }}
 ```
 
 #### escape


### PR DESCRIPTION
While using the built-in `date` filter, a specific timezone can
only be set for ISO 8601 date strings. This commit makes it possible
to supply a timezone for i64 timestamps (seconds since epoch).

Example usage: `{{ 1648302603 | date(timezone="Turkey") }}`

Signed-off-by: Orhun Parmaksız <orhunparmaksiz@gmail.com>
