### PR TITLE
better parenthesis support (#718)

### DIFF
--- a/src/parser/tera.pest
+++ b/src/parser/tera.pest
@@ -86,7 +86,7 @@ string_concat = { (fn_call | float | int | string | dotted_square_bracket_ident)
 // boolean first so they are not caught as identifiers
 basic_val  = _{ boolean | test_not | test | macro_call | fn_call | dotted_square_bracket_ident | float | int }
 basic_op   = _{ op_plus | op_minus | op_times | op_slash | op_modulo }
-basic_expr = { ("(" ~ basic_expr ~ ")" | basic_val) ~ (basic_op ~ basic_val)* }
+basic_expr = { ("(" ~ basic_expr ~ ")" | basic_val) ~ (basic_op ~ ("(" ~ basic_expr ~ ")" | basic_val))* }
 basic_expr_filter = !{ basic_expr ~ filter* }
 string_expr_filter = !{ (string_concat | string) ~ filter* }
 

--- a/src/renderer/tests/basic.rs
+++ b/src/renderer/tests/basic.rs
@@ -124,6 +124,10 @@ fn render_variable_block_ident() {
         ("{{ 1.9 + a | round - 1 }}", "3"),
         ("{{ 1.9 + a | round - 1.8 + a | round }}", "0"),
         ("{{ 1.9 + a | round - 1.8 + a | round - 1 }}", "-1"),
+        ("{{ 4 + 40 / (2 + 8) / 4 }}", "5"),
+        ("{{ ( ( 2 ) + ( 2 ) ) }}", "4"),
+        ("{{ ( ( 4 / 1 ) + ( 2 / 1 ) ) }}", "6"),
+        ("{{ ( ( 4 + 2 ) / ( 2 + 1 ) ) }}", "2"),
         // https://github.com/Keats/tera/issues/435
         (
             "{{ with_newline | replace(from='\n', to='<br>') | safe }}",


### PR DESCRIPTION
- overall math expression parehthesis
- better support for the order of math operations signified by the parenthesis