### PR TITLE
feat(date): locale (#612)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ default = ["builtins"]
 builtins = ["urlencode", "slug", "humansize", "chrono", "chrono-tz", "rand"]
 urlencode = ["percent-encoding"]
 preserve_order = ["serde_json/preserve_order"]
+date-locale = ["builtins", "chrono/unstable-locales"]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/docs/content/docs/_index.md
+++ b/docs/content/docs/_index.md
@@ -1199,6 +1199,10 @@ Example:
 {{ 1648252203 | date(timezone="Europe/Berlin") }}
 ```
 
+Locale can be specified (excepted when the input is a timestamp without timezone argument), default being POSIX. (only available if the `date-locale` feature is enabled)
+
+Example: `{{ 1648252203 | date(format="%A %-d %B", timezone="Europe/Paris", locale="fr_FR") }}`
+
 #### escape
 Escapes a string's HTML. Specifically, it makes these replacements:
 


### PR DESCRIPTION
Adds optional `locale` argument in `date` filter, including doc and tests.

Notes:
* For some(?) reason, `chrono::NaiveDateTime::format_localized` does not exist, so timestamps without timezone cannot be localized.
* In order to avoid code duplication, `format_localized` is used event when a locale is not provided (using `chrono`'s default `POSIX`). Looking at `chrono`'s code, this should not affect performance.
* Adds `chrono/unstable-locales`, which may be heavy and restrict `chrono` versions. Should this be in a feature `date-locale`?