### PR TITLE
eval_in_condition: Use safe_eval rather than eval (#738)

### DIFF
--- a/src/renderer/processor.rs
+++ b/src/renderer/processor.rs
@@ -303,8 +303,8 @@ impl<'a> Processor<'a> {
     }
 
     fn eval_in_condition(&mut self, in_cond: &'a In) -> Result<bool> {
-        let lhs = self.eval_expression(&in_cond.lhs)?;
-        let rhs = self.eval_expression(&in_cond.rhs)?;
+        let lhs = self.safe_eval_expression(&in_cond.lhs)?;
+        let rhs = self.safe_eval_expression(&in_cond.rhs)?;
 
         let present = match *rhs {
             Value::Array(ref v) => v.contains(&lhs),

--- a/src/renderer/tests/basic.rs
+++ b/src/renderer/tests/basic.rs
@@ -151,6 +151,7 @@ fn render_variable_block_logic_expr() {
     hashmap.insert("b", 10);
     hashmap.insert("john", 100);
     context.insert("object", &hashmap);
+    context.insert("urls", &vec!["https://test"]);
 
     let inputs = vec![
         ("{{ (1.9 + a) | round > 10 }}", "false"),
@@ -177,6 +178,8 @@ fn render_variable_block_logic_expr() {
         ("{{ name not in 'hello' }}", "true"),
         ("{{ name in ['bob', 2, 'john'] }}", "true"),
         ("{{ a in ['bob', 2, 'john'] }}", "true"),
+        ("{{ \"https://test\" in [\"https://test\"] }}", "true"),
+        ("{{ \"https://test\" in urls }}", "true"),
         ("{{ 'n' in name }}", "true"),
         ("{{ '<' in malicious }}", "true"),
         ("{{ 'a' in object }}", "true"),


### PR DESCRIPTION
Fixes #738

- Added two simple tests to ensure there isn't a regression
- The fix is simple though would appreciate a sanity check, specifically that calling `safe_eval_expression` in `eval_in_condition` can't result in safety issues
  - I don't believe it does but a double check from someone more familiarly with the codebase would be appreciated =]