### PR TITLE
Bump chrono to 0.4.20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ percent-encoding = {version = "2.1", optional = true}
 # used in filesizeformat filter
 humansize = {version = "1", optional = true}
 # used in date format filter
-chrono = {version = "0.4.1", optional = true, default-features = false, features = ["std", "clock"]}
+chrono = {version = "0.4.20", optional = true, default-features = false, features = ["std", "clock"]}
 chrono-tz = {version = "0.6", optional = true}
 # used in get_random function
 rand = {version = "0.8", optional = true}


### PR DESCRIPTION
Chrono now - 0.4.20 - has localtime_r RIR that has addressed the past security issue around it :partying_face: 

We've updated here:
https://rustsec.org/advisories/RUSTSEC-2020-0159.html