### PR TITLE
Update pest deps to latest version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ include = ["/src/**/*", "/LICENSE", "/README.md", "/CHANGELOG.md"]
 globwalk = "0.8.1"
 serde = "1.0"
 serde_json = "1.0.11"
-pest = "2.0.2"
-pest_derive = "2.0.2"
+pest = "2.3.0"
+pest_derive = "2.3.0"
 lazy_static = "1.0"
 # used in striptags, spaceless & titles filters. Already pulled by globwalk
 regex = "1.0"


### PR DESCRIPTION
This PR updates the pest dependency version with the latest one (2.3.0)