### PR TITLE
Fix wrong type in `get_random` error message.

### DIFF
--- a/src/builtins/functions.rs
+++ b/src/builtins/functions.rs
@@ -145,7 +145,7 @@ pub fn get_random(args: &HashMap<String, Value>) -> Result<Value> {
             Ok(v) => v,
             Err(_) => {
                 return Err(Error::msg(format!(
-                    "Function `get_random` received start={} but `start` can only be a boolean",
+                    "Function `get_random` received start={} but `start` can only be a number",
                     val
                 )));
             }
@@ -158,7 +158,7 @@ pub fn get_random(args: &HashMap<String, Value>) -> Result<Value> {
             Ok(v) => v,
             Err(_) => {
                 return Err(Error::msg(format!(
-                    "Function `get_random` received end={} but `end` can only be a boolean",
+                    "Function `get_random` received end={} but `end` can only be a number",
                     val
                 )));
             }


### PR DESCRIPTION
Those errors are also reported for numbers overflowing an `i32` (e.g. `get_random(end=9999999999)`) which is also confusing, but less so than saying a boolean was expected.

All the other functions in this file seem to have the correct types reported.