### PR TITLE
Title case filter with apostrophe (#771)

### DIFF
--- a/src/builtins/filters/string.rs
+++ b/src/builtins/filters/string.rs
@@ -61,7 +61,7 @@ const PYTHON_ENCODE_SET: &AsciiSet = &USERINFO_ENCODE_SET
 
 lazy_static! {
     static ref STRIPTAGS_RE: Regex = Regex::new(r"(<!--.*?-->|<[^>]*>)").unwrap();
-    static ref WORDS_RE: Regex = Regex::new(r"\b(?P<first>\w)(?P<rest>\w*)\b").unwrap();
+    static ref WORDS_RE: Regex = Regex::new(r"\b(?P<first>[\w'])(?P<rest>[\w']*)\b").unwrap();
     static ref SPACELESS_RE: Regex = Regex::new(r">\s+<").unwrap();
 }
 
@@ -662,6 +662,7 @@ mod tests {
             ("\tfoo\tbar\t", "\tFoo\tBar\t"),
             ("foo bar ", "Foo Bar "),
             ("foo bar\t", "Foo Bar\t"),
+            ("foo's bar", "Foo's Bar"),
         ];
         for (input, expected) in tests {
             let result = title(&to_value(input).unwrap(), &HashMap::new());


### PR DESCRIPTION
Fixes #771

Tested locally with latest version and Rust on Windows 11. More tests may be needed.