### PR TITLE
Remove unused [badges] section in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,3 @@ builtins = ["urlencode", "slug", "humansize", "chrono", "chrono-tz", "rand"]
 urlencode = ["percent-encoding"]
 preserve_order = ["serde_json/preserve_order"]
 date-locale = ["builtins", "chrono/unstable-locales"]
-
-[badges]
-maintenance = { status = "actively-developed" }


### PR DESCRIPTION
As per https://doc.rust-lang.org/cargo/reference/manifest.html#the-badges-section, that section is not used by crates.io anymore.