### PR TITLE
Fix clippy 0.1.68

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,18 +16,18 @@ include = ["/src/**/*", "/LICENSE", "/README.md", "/CHANGELOG.md"]
 globwalk = "0.8.1"
 serde = "1.0"
 serde_json = "1.0.93"
-pest = "2.3.0"
-pest_derive = "2.3.0"
+pest = "2.5.5"
+pest_derive = "2.5.5"
 lazy_static = "1.4"
 # used in striptags, spaceless & titles filters. Already pulled by globwalk
-regex = "1.0"
+regex = "1.7"
 # used in truncate filter and string iteration
 unic-segment = "0.9"
 
 # used in slugify filter
-slug = {version = "0.1.1", optional = true}
+slug = {version = "0.1.4", optional = true}
 # used in urlencode filter
-percent-encoding = {version = "2.1", optional = true}
+percent-encoding = {version = "2.2", optional = true}
 # used in filesizeformat filter
 humansize = {version = "1", optional = true}
 # used in date format filter

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,10 @@ include = ["/src/**/*", "/LICENSE", "/README.md", "/CHANGELOG.md"]
 [dependencies]
 globwalk = "0.8.1"
 serde = "1.0"
-serde_json = "1.0.11"
+serde_json = "1.0.93"
 pest = "2.3.0"
 pest_derive = "2.3.0"
-lazy_static = "1.0"
+lazy_static = "1.4"
 # used in striptags, spaceless & titles filters. Already pulled by globwalk
 regex = "1.0"
 # used in truncate filter and string iteration
@@ -31,10 +31,11 @@ percent-encoding = {version = "2.1", optional = true}
 # used in filesizeformat filter
 humansize = {version = "1", optional = true}
 # used in date format filter
-chrono = {version = "0.4.20", optional = true, default-features = false, features = ["std", "clock"]}
-chrono-tz = {version = "0.6", optional = true}
+chrono = {version = "0.4.23", optional = true, default-features = false, features = ["std", "clock"]}
+chrono-tz = {version = "0.8.1", optional = true}
 # used in get_random function
 rand = {version = "0.8", optional = true}
+
 
 [dev-dependencies]
 serde_derive = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ slug = {version = "0.1.4", optional = true}
 # used in urlencode filter
 percent-encoding = {version = "2.2", optional = true}
 # used in filesizeformat filter
-humansize = {version = "1", optional = true}
+humansize = {version = "2.1.3", optional = true}
 # used in date format filter
 chrono = {version = "0.4.23", optional = true, default-features = false, features = ["std", "clock"]}
 chrono-tz = {version = "0.8.1", optional = true}

--- a/benches/big_context.rs
+++ b/benches/big_context.rs
@@ -167,7 +167,7 @@ impl ManyFields {
         }
         let mut e = Vec::new();
         for i in 0..100 {
-            e.push(format!("This is String({})", i));
+            e.push(format!("This is String({i})"));
         }
 
         ManyFields { a: "A".into(), b: "B".into(), c: "C".into(), d, e }

--- a/benches/escaping.rs
+++ b/benches/escaping.rs
@@ -4,13 +4,13 @@ extern crate test;
 
 use tera::escape_html;
 
-const NO_HTML_SHORT: &'static str = "A paragraph without HTML characters that need to be escaped.";
-const NO_HTML_LONG: &'static str = "Another paragraph without characters that need to be escaped. This paragraph is a bit longer, as sometimes there can be large paragraphs that don't any special characters, e.g., in novels or whatever.";
-const HTML_SHORT: &'static str = "Here->An <<example>> of rust codefn foo(u: &u32) -> &u32 {u}";
-const HTML_LONG: &'static str = "A somewhat longer paragraph containing a character that needs to be escaped, because e.g. the author mentions the movie Fast&Furious in it. This paragraph is also quite long to match the non-html one.";
+const NO_HTML_SHORT: &str = "A paragraph without HTML characters that need to be escaped.";
+const NO_HTML_LONG: &str = "Another paragraph without characters that need to be escaped. This paragraph is a bit longer, as sometimes there can be large paragraphs that don't any special characters, e.g., in novels or whatever.";
+const HTML_SHORT: &str = "Here->An <<example>> of rust codefn foo(u: &u32) -> &u32 {u}";
+const HTML_LONG: &str = "A somewhat longer paragraph containing a character that needs to be escaped, because e.g. the author mentions the movie Fast&Furious in it. This paragraph is also quite long to match the non-html one.";
 
 // taken from https://github.com/djc/askama/blob/master/askama_escape/benches/all.rs
-const NO_HTML_VERY_LONG: &'static str = r#"
+const NO_HTML_VERY_LONG: &str = r#"
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin scelerisque eu urna in aliquet.
 Phasellus ac nulla a urna sagittis consequat id quis est. Nullam eu ex eget erat accumsan dictum
 ac lobortis urna. Etiam fermentum ut quam at dignissim. Curabitur vestibulum luctus tellus, sit
@@ -24,7 +24,7 @@ vulputate euismod lectus vestibulum nec. Donec sit amet massa magna. Nunc ipsum 
 quis lacus at, gravida maximus elit. Duis tristique, nisl nullam.
     "#;
 
-const HTML_VERY_LONG: &'static str = r#"
+const HTML_VERY_LONG: &str = r#"
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris consequat tellus sit
     amet ornare fermentum. Etiam nec erat ante. In at metus a orci mollis scelerisque.
     Sed eget ultrices turpis, at sollicitudin erat. Integer hendrerit nec magna quis

--- a/benches/templates.rs
+++ b/benches/templates.rs
@@ -29,7 +29,7 @@ pub fn big_table(b: &mut test::Bencher) {
     b.iter(|| tera.render("big-table.html", &ctx));
 }
 
-static BIG_TABLE_TEMPLATE: &'static str = "<table>
+static BIG_TABLE_TEMPLATE: &str = "<table>
 {% for row in table %}
 <tr>{% for col in row %}<td>{{ col }}</td>{% endfor %}</tr>
 {% endfor %}
@@ -60,7 +60,7 @@ pub fn teams(b: &mut test::Bencher) {
     b.iter(|| tera.render("teams.html", &ctx));
 }
 
-static TEAMS_TEMPLATE: &'static str = "<html>
+static TEAMS_TEMPLATE: &str = "<html>
   <head>
     <title>{{ year }}</title>
   </head>

--- a/benches/tera.rs
+++ b/benches/tera.rs
@@ -7,9 +7,9 @@ extern crate serde_json;
 
 use tera::{Context, Template, Tera, Value};
 
-static VARIABLE_ONLY: &'static str = "{{product.name}}";
+static VARIABLE_ONLY: &str = "{{product.name}}";
 
-static SIMPLE_TEMPLATE: &'static str = "
+static SIMPLE_TEMPLATE: &str = "
 <html>
   <head>
     <title>{{ product.name }}</title>
@@ -24,7 +24,7 @@ static SIMPLE_TEMPLATE: &'static str = "
 </html>
 ";
 
-static PARENT_TEMPLATE: &'static str = "
+static PARENT_TEMPLATE: &str = "
 <html>
   <head>
     <title>{% block title %}Hello{% endblock title%}</title>
@@ -35,7 +35,7 @@ static PARENT_TEMPLATE: &'static str = "
 </html>
 ";
 
-static MACRO_TEMPLATE: &'static str = "
+static MACRO_TEMPLATE: &str = "
 {% macro render_product(product) %}
     <h1>{{ product.name }} - {{ product.manufacturer | upper }}</h1>
     <p>{{ product.summary }}</p>
@@ -44,13 +44,13 @@ static MACRO_TEMPLATE: &'static str = "
 {% endmacro render_product %}
 ";
 
-static CHILD_TEMPLATE: &'static str = r#"{% extends "parent.html" %}
+static CHILD_TEMPLATE: &str = r#"{% extends "parent.html" %}
 {% block title %}{{ super() }} - {{ username | lower }}{% endblock title %}
 
 {% block body %}body{% endblock body %}
 "#;
 
-static CHILD_TEMPLATE_WITH_MACRO: &'static str = r#"{% extends "parent.html" %}
+static CHILD_TEMPLATE_WITH_MACRO: &str = r#"{% extends "parent.html" %}
 {% import "macros.html" as macros %}
 
 {% block title %}{{ super() }} - {{ username | lower }}{% endblock title %}
@@ -60,7 +60,7 @@ static CHILD_TEMPLATE_WITH_MACRO: &'static str = r#"{% extends "parent.html" %}
 {% endblock body %}
 "#;
 
-static USE_MACRO_TEMPLATE: &'static str = r#"
+static USE_MACRO_TEMPLATE: &str = r#"
 {% import "macros.html" as macros %}
 {{ macros::render_product(product=product) }}
 "#;
@@ -198,9 +198,9 @@ fn bench_huge_loop(b: &mut test::Bencher) {
         dummy: Vec<DataWrapper>,
     }
     let real: Vec<DataWrapper> =
-        (1..1000).into_iter().map(|i| DataWrapper { v: format!("n={}", i) }).collect();
+        (1..1000).map(|i| DataWrapper { v: format!("n={i}") }).collect();
     let dummy: Vec<DataWrapper> =
-        (1..1000).into_iter().map(|i| DataWrapper { v: format!("n={}", i) }).collect();
+        (1..1000).map(|i| DataWrapper { v: format!("n={i}") }).collect();
     let rows = RowWrapper { real, dummy };
 
     let mut tera = Tera::default();

--- a/examples/basic/main.rs
+++ b/examples/basic/main.rs
@@ -15,7 +15,7 @@ lazy_static! {
         let mut tera = match Tera::new("examples/basic/templates/**/*") {
             Ok(t) => t,
             Err(e) => {
-                println!("Parsing error(s): {}", e);
+                println!("Parsing error(s): {e}");
                 ::std::process::exit(1);
             }
         };
@@ -27,7 +27,7 @@ lazy_static! {
 
 pub fn do_nothing_filter(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
     let s = try_get_value!("do_nothing_filter", "value", String, value);
-    Ok(to_value(&s).unwrap())
+    Ok(to_value(s).unwrap())
 }
 
 fn main() {
@@ -41,12 +41,12 @@ fn main() {
     Tera::one_off("hello", &Context::new(), true).unwrap();
 
     match TEMPLATES.render("users/profile.html", &context) {
-        Ok(s) => println!("{:?}", s),
+        Ok(s) => println!("{s:?}"),
         Err(e) => {
-            println!("Error: {}", e);
+            println!("Error: {e}");
             let mut cause = e.source();
             while let Some(e) = cause {
-                println!("Reason: {}", e);
+                println!("Reason: {e}");
                 cause = e.source();
             }
         }

--- a/examples/bench/main.rs
+++ b/examples/bench/main.rs
@@ -6,7 +6,7 @@ use tera::{Context, Tera};
 #[global_allocator]
 static GLOBAL: System = System;
 
-static BIG_TABLE_TEMPLATE: &'static str = "<table>
+static BIG_TABLE_TEMPLATE: &str = "<table>
 {% for row in table %}
 <tr>{% for col in row %}<td>{{ col }}</td>{% endfor %}</tr>
 {% endfor %}

--- a/src/builtins/filters/array.rs
+++ b/src/builtins/filters/array.rs
@@ -80,13 +80,13 @@ pub fn sort(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
     };
 
     let first = arr[0].pointer(&ptr).ok_or_else(|| {
-        Error::msg(format!("attribute '{}' does not reference a field", attribute))
+        Error::msg(format!("attribute '{attribute}' does not reference a field"))
     })?;
 
     let mut strategy = get_sort_strategy_for_type(first)?;
     for v in &arr {
         let key = v.pointer(&ptr).ok_or_else(|| {
-            Error::msg(format!("attribute '{}' does not reference a field", attribute))
+            Error::msg(format!("attribute '{attribute}' does not reference a field"))
         })?;
         strategy.try_add_pair(v, key)?;
     }
@@ -119,7 +119,7 @@ pub fn unique(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
     };
 
     let first = arr[0].pointer(&ptr).ok_or_else(|| {
-        Error::msg(format!("attribute '{}' does not reference a field", attribute))
+        Error::msg(format!("attribute '{attribute}' does not reference a field"))
     })?;
 
     let disc = std::mem::discriminant(first);
@@ -173,7 +173,7 @@ pub fn group_by(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
 
             let str_key = match key_val.as_str() {
                 Some(key) => key.to_owned(),
-                None => format!("{}", key_val),
+                None => format!("{key_val}"),
             };
 
             if let Some(vals) = grouped.get_mut(&str_key) {

--- a/src/builtins/filters/array.rs
+++ b/src/builtins/filters/array.rs
@@ -59,7 +59,7 @@ pub fn join(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
         .iter()
         .map(|v| render_to_string(|| "joining array".to_string(), |w| v.render(w)))
         .collect::<Result<Vec<_>>>()?;
-    to_value(&rendered.join(&sep)).map_err(Error::json)
+    to_value(rendered.join(&sep)).map_err(Error::json)
 }
 
 /// Sorts the array in ascending order.
@@ -323,9 +323,9 @@ mod tests {
     fn test_nth() {
         let mut args = HashMap::new();
         args.insert("n".to_string(), to_value(1).unwrap());
-        let result = nth(&to_value(&vec![1, 2, 3, 4]).unwrap(), &args);
+        let result = nth(&to_value(vec![1, 2, 3, 4]).unwrap(), &args);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), to_value(&2).unwrap());
+        assert_eq!(result.unwrap(), to_value(2).unwrap());
     }
 
     #[test]
@@ -333,30 +333,30 @@ mod tests {
         let v: Vec<Value> = Vec::new();
         let mut args = HashMap::new();
         args.insert("n".to_string(), to_value(1).unwrap());
-        let result = nth(&to_value(&v).unwrap(), &args);
+        let result = nth(&to_value(v).unwrap(), &args);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), to_value("").unwrap());
     }
 
     #[test]
     fn test_first() {
-        let result = first(&to_value(&vec![1, 2, 3, 4]).unwrap(), &HashMap::new());
+        let result = first(&to_value(vec![1, 2, 3, 4]).unwrap(), &HashMap::new());
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), to_value(&1).unwrap());
+        assert_eq!(result.unwrap(), to_value(1).unwrap());
     }
 
     #[test]
     fn test_first_empty() {
         let v: Vec<Value> = Vec::new();
 
-        let result = first(&to_value(&v).unwrap(), &HashMap::new());
+        let result = first(&to_value(v).unwrap(), &HashMap::new());
         assert!(result.is_ok());
         assert_eq!(result.ok().unwrap(), to_value("").unwrap());
     }
 
     #[test]
     fn test_last() {
-        let result = last(&to_value(&vec!["Hello", "World"]).unwrap(), &HashMap::new());
+        let result = last(&to_value(vec!["Hello", "World"]).unwrap(), &HashMap::new());
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), to_value("World").unwrap());
     }
@@ -365,7 +365,7 @@ mod tests {
     fn test_last_empty() {
         let v: Vec<Value> = Vec::new();
 
-        let result = last(&to_value(&v).unwrap(), &HashMap::new());
+        let result = last(&to_value(v).unwrap(), &HashMap::new());
         assert!(result.is_ok());
         assert_eq!(result.ok().unwrap(), to_value("").unwrap());
     }
@@ -373,29 +373,29 @@ mod tests {
     #[test]
     fn test_join_sep() {
         let mut args = HashMap::new();
-        args.insert("sep".to_owned(), to_value(&"==").unwrap());
+        args.insert("sep".to_owned(), to_value("==").unwrap());
 
-        let result = join(&to_value(&vec!["Cats", "Dogs"]).unwrap(), &args);
+        let result = join(&to_value(vec!["Cats", "Dogs"]).unwrap(), &args);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), to_value(&"Cats==Dogs").unwrap());
+        assert_eq!(result.unwrap(), to_value("Cats==Dogs").unwrap());
     }
 
     #[test]
     fn test_join_sep_omitted() {
-        let result = join(&to_value(&vec![1.2, 3.4]).unwrap(), &HashMap::new());
+        let result = join(&to_value(vec![1.2, 3.4]).unwrap(), &HashMap::new());
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), to_value(&"1.23.4").unwrap());
+        assert_eq!(result.unwrap(), to_value("1.23.4").unwrap());
     }
 
     #[test]
     fn test_join_empty() {
         let v: Vec<Value> = Vec::new();
         let mut args = HashMap::new();
-        args.insert("sep".to_owned(), to_value(&"==").unwrap());
+        args.insert("sep".to_owned(), to_value("==").unwrap());
 
-        let result = join(&to_value(&v).unwrap(), &args);
+        let result = join(&to_value(v).unwrap(), &args);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), to_value(&"").unwrap());
+        assert_eq!(result.unwrap(), to_value("").unwrap());
     }
 
     #[test]
@@ -432,7 +432,7 @@ mod tests {
         ])
         .unwrap();
         let mut args = HashMap::new();
-        args.insert("attribute".to_string(), to_value(&"a").unwrap());
+        args.insert("attribute".to_string(), to_value("a").unwrap());
 
         let result = sort(&v, &args);
         assert!(result.is_ok());
@@ -452,7 +452,7 @@ mod tests {
     fn test_sort_invalid_attribute() {
         let v = to_value(vec![Foo { a: 3, b: 5 }]).unwrap();
         let mut args = HashMap::new();
-        args.insert("attribute".to_string(), to_value(&"invalid_field").unwrap());
+        args.insert("attribute".to_string(), to_value("invalid_field").unwrap());
 
         let result = sort(&v, &args);
         assert!(result.is_err());
@@ -557,7 +557,7 @@ mod tests {
         ])
         .unwrap();
         let mut args = HashMap::new();
-        args.insert("attribute".to_string(), to_value(&"a").unwrap());
+        args.insert("attribute".to_string(), to_value("a").unwrap());
 
         let result = unique(&v, &args);
         assert!(result.is_ok());
@@ -571,7 +571,7 @@ mod tests {
     fn test_unique_invalid_attribute() {
         let v = to_value(vec![Foo { a: 3, b: 5 }]).unwrap();
         let mut args = HashMap::new();
-        args.insert("attribute".to_string(), to_value(&"invalid_field").unwrap());
+        args.insert("attribute".to_string(), to_value("invalid_field").unwrap());
 
         let result = unique(&v, &args);
         assert!(result.is_err());

--- a/src/builtins/filters/common.rs
+++ b/src/builtins/filters/common.rs
@@ -41,8 +41,7 @@ pub fn reverse(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
         Value::String(s) => to_value(&String::from_iter(s.chars().rev())).map_err(Error::json),
         _ => Err(Error::msg(format!(
             "Filter `reverse` received an incorrect type for arg `value`: \
-             got `{}` but expected Array|String",
-            value
+             got `{value}` but expected Array|String"
         ))),
     }
 }
@@ -81,7 +80,7 @@ pub fn date(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
         })
         .collect();
     if !items.is_empty() {
-        return Err(Error::msg(format!("Invalid date format `{}`", format)));
+        return Err(Error::msg(format!("Invalid date format `{format}`")));
     }
 
     let timezone = match args.get("timezone") {
@@ -90,7 +89,7 @@ pub fn date(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
             match timezone.parse::<Tz>() {
                 Ok(timezone) => Some(timezone),
                 Err(_) => {
-                    return Err(Error::msg(format!("Error parsing `{}` as a timezone", timezone)))
+                    return Err(Error::msg(format!("Error parsing `{timezone}` as a timezone")))
                 }
             }
         }
@@ -176,7 +175,7 @@ pub fn date(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
                     None => date.format(&format),
                 }
             }
-            None => return Err(Error::msg(format!("Filter `date` was invoked on a float: {}", n))),
+            None => return Err(Error::msg(format!("Filter `date` was invoked on a float: {n}"))),
         },
         Value::String(s) => {
             if s.contains('T') {
@@ -189,8 +188,7 @@ pub fn date(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
                         Ok(val) => DateTime::<Utc>::from_utc(val, Utc).format(&format),
                         Err(_) => {
                             return Err(Error::msg(format!(
-                                "Error parsing `{:?}` as rfc3339 date or naive datetime",
-                                s
+                                "Error parsing `{s:?}` as rfc3339 date or naive datetime"
                             )));
                         }
                     },
@@ -200,8 +198,7 @@ pub fn date(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
                     Ok(val) => DateTime::<Utc>::from_utc(val.and_hms(0, 0, 0), Utc).format(&format),
                     Err(_) => {
                         return Err(Error::msg(format!(
-                            "Error parsing `{:?}` as YYYY-MM-DD date",
-                            s
+                            "Error parsing `{s:?}` as YYYY-MM-DD date"
                         )));
                     }
                 }
@@ -210,8 +207,7 @@ pub fn date(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
         _ => {
             return Err(Error::msg(format!(
                 "Filter `date` received an incorrect type for arg `value`: \
-                 got `{:?}` but expected i64|u64|String",
-                value
+                 got `{value:?}` but expected i64|u64|String"
             )));
         }
     };
@@ -222,7 +218,7 @@ pub fn date(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
 // Returns the given value as a string.
 pub fn as_str(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
     let value =
-        render_to_string(|| format!("as_str for value of kind {}", value), |w| value.render(w))?;
+        render_to_string(|| format!("as_str for value of kind {value}"), |w| value.render(w))?;
     to_value(value).map_err(Error::json)
 }
 
@@ -376,7 +372,7 @@ mod tests {
         let mut args = HashMap::new();
         args.insert("format".to_string(), to_value("%a, %d %b %Y %H:%M:%S").unwrap());
         let result = date(&to_value("2017-03-05T00:00:00.602").unwrap(), &args);
-        println!("{:?}", result);
+        println!("{result:?}");
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), to_value("Sun, 05 Mar 2017 00:00:00").unwrap());
     }

--- a/src/builtins/filters/common.rs
+++ b/src/builtins/filters/common.rs
@@ -21,9 +21,9 @@ use crate::context::ValueRender;
 // Returns the number of items in an array or an object, or the number of characters in a string.
 pub fn length(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
     match value {
-        Value::Array(arr) => Ok(to_value(&arr.len()).unwrap()),
-        Value::Object(m) => Ok(to_value(&m.len()).unwrap()),
-        Value::String(s) => Ok(to_value(&s.chars().count()).unwrap()),
+        Value::Array(arr) => Ok(to_value(arr.len()).unwrap()),
+        Value::Object(m) => Ok(to_value(m.len()).unwrap()),
+        Value::String(s) => Ok(to_value(s.chars().count()).unwrap()),
         _ => Err(Error::msg(
             "Filter `length` was used on a value that isn't an array, an object, or a string.",
         )),
@@ -38,7 +38,7 @@ pub fn reverse(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
             rev.reverse();
             to_value(&rev).map_err(Error::json)
         }
-        Value::String(s) => to_value(&String::from_iter(s.chars().rev())).map_err(Error::json),
+        Value::String(s) => to_value(String::from_iter(s.chars().rev())).map_err(Error::json),
         _ => Err(Error::msg(format!(
             "Filter `reverse` received an incorrect type for arg `value`: \
              got `{value}` but expected Array|String"
@@ -194,7 +194,7 @@ pub fn date(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
                     },
                 }
             } else {
-                match NaiveDate::parse_from_str(&s, "%Y-%m-%d") {
+                match NaiveDate::parse_from_str(s, "%Y-%m-%d") {
                     Ok(val) => DateTime::<Utc>::from_utc(val.and_hms(0, 0, 0), Utc).format(&format),
                     Err(_) => {
                         return Err(Error::msg(format!(
@@ -212,7 +212,7 @@ pub fn date(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
         }
     };
 
-    to_value(&formatted.to_string()).map_err(Error::json)
+    to_value(formatted.to_string()).map_err(Error::json)
 }
 
 // Returns the given value as a string.
@@ -234,23 +234,23 @@ mod tests {
     #[test]
     fn as_str_object() {
         let map: HashMap<String, String> = HashMap::new();
-        let result = as_str(&to_value(&map).unwrap(), &HashMap::new());
+        let result = as_str(&to_value(map).unwrap(), &HashMap::new());
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), to_value(&"[object]").unwrap());
+        assert_eq!(result.unwrap(), to_value("[object]").unwrap());
     }
 
     #[test]
     fn as_str_vec() {
-        let result = as_str(&to_value(&vec![1, 2, 3, 4]).unwrap(), &HashMap::new());
+        let result = as_str(&to_value(vec![1, 2, 3, 4]).unwrap(), &HashMap::new());
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), to_value(&"[1, 2, 3, 4]").unwrap());
+        assert_eq!(result.unwrap(), to_value("[1, 2, 3, 4]").unwrap());
     }
 
     #[test]
     fn length_vec() {
-        let result = length(&to_value(&vec![1, 2, 3, 4]).unwrap(), &HashMap::new());
+        let result = length(&to_value(vec![1, 2, 3, 4]).unwrap(), &HashMap::new());
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), to_value(&4).unwrap());
+        assert_eq!(result.unwrap(), to_value(4).unwrap());
     }
 
     #[test]
@@ -259,46 +259,46 @@ mod tests {
         map.insert("foo".to_string(), "bar".to_string());
         let result = length(&to_value(&map).unwrap(), &HashMap::new());
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), to_value(&1).unwrap());
+        assert_eq!(result.unwrap(), to_value(1).unwrap());
     }
 
     #[test]
     fn length_str() {
-        let result = length(&to_value(&"Hello World").unwrap(), &HashMap::new());
+        let result = length(&to_value("Hello World").unwrap(), &HashMap::new());
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), to_value(&11).unwrap());
+        assert_eq!(result.unwrap(), to_value(11).unwrap());
     }
 
     #[test]
     fn length_str_nonascii() {
-        let result = length(&to_value(&"日本語").unwrap(), &HashMap::new());
+        let result = length(&to_value("日本語").unwrap(), &HashMap::new());
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), to_value(&3).unwrap());
+        assert_eq!(result.unwrap(), to_value(3).unwrap());
     }
 
     #[test]
     fn length_num() {
-        let result = length(&to_value(&15).unwrap(), &HashMap::new());
+        let result = length(&to_value(15).unwrap(), &HashMap::new());
         assert!(result.is_err());
     }
 
     #[test]
     fn reverse_vec() {
-        let result = reverse(&to_value(&vec![1, 2, 3, 4]).unwrap(), &HashMap::new());
+        let result = reverse(&to_value(vec![1, 2, 3, 4]).unwrap(), &HashMap::new());
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), to_value(&vec![4, 3, 2, 1]).unwrap());
+        assert_eq!(result.unwrap(), to_value(vec![4, 3, 2, 1]).unwrap());
     }
 
     #[test]
     fn reverse_str() {
-        let result = reverse(&to_value(&"Hello World").unwrap(), &HashMap::new());
+        let result = reverse(&to_value("Hello World").unwrap(), &HashMap::new());
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), to_value(&"dlroW olleH").unwrap());
+        assert_eq!(result.unwrap(), to_value("dlroW olleH").unwrap());
     }
 
     #[test]
     fn reverse_num() {
-        let result = reverse(&to_value(&1.23).unwrap(), &HashMap::new());
+        let result = reverse(&to_value(1.23).unwrap(), &HashMap::new());
         assert!(result.is_err());
         assert_eq!(
             result.err().unwrap().to_string(),

--- a/src/builtins/filters/common.rs
+++ b/src/builtins/filters/common.rs
@@ -73,12 +73,8 @@ pub fn date(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
         None => "%Y-%m-%d".to_string(),
     };
 
-    let items: Vec<Item> = StrftimeItems::new(&format)
-        .filter(|item| match item {
-            Item::Error => true,
-            _ => false,
-        })
-        .collect();
+    let items: Vec<Item> =
+        StrftimeItems::new(&format).filter(|item| matches!(item, Item::Error)).collect();
     if !items.is_empty() {
         return Err(Error::msg(format!("Invalid date format `{format}`")));
     }

--- a/src/builtins/filters/number.rs
+++ b/src/builtins/filters/number.rs
@@ -2,7 +2,7 @@
 use std::collections::HashMap;
 
 #[cfg(feature = "builtins")]
-use humansize::{file_size_opts, FileSize};
+use humansize::format_size;
 use serde_json::value::{to_value, Value};
 
 use crate::errors::{Error, Result};
@@ -62,12 +62,7 @@ pub fn round(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
 #[cfg(feature = "builtins")]
 pub fn filesizeformat(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
     let num = try_get_value!("filesizeformat", "value", usize, value);
-    num.file_size(file_size_opts::CONVENTIONAL)
-        .map_err(|_| {
-            Error::msg(format!("Filter `filesizeformat` was called on a negative number: {num}"))
-        })
-        .map(to_value)
-        .map(std::result::Result::unwrap)
+    Ok(to_value(format_size(num, humansize::DECIMAL)).expect("json serializing should always be possible for a string"))
 }
 
 #[cfg(test)]

--- a/src/builtins/filters/number.rs
+++ b/src/builtins/filters/number.rs
@@ -52,9 +52,8 @@ pub fn round(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
         "ceil" => Ok(to_value((multiplier * num).ceil() / multiplier).unwrap()),
         "floor" => Ok(to_value((multiplier * num).floor() / multiplier).unwrap()),
         _ => Err(Error::msg(format!(
-            "Filter `round` received an incorrect value for arg `method`: got `{:?}`, \
-             only common, ceil and floor are allowed",
-            method
+            "Filter `round` received an incorrect value for arg `method`: got `{method:?}`, \
+             only common, ceil and floor are allowed"
         ))),
     }
 }
@@ -65,7 +64,7 @@ pub fn filesizeformat(value: &Value, _: &HashMap<String, Value>) -> Result<Value
     let num = try_get_value!("filesizeformat", "value", usize, value);
     num.file_size(file_size_opts::CONVENTIONAL)
         .map_err(|_| {
-            Error::msg(format!("Filter `filesizeformat` was called on a negative number: {}", num))
+            Error::msg(format!("Filter `filesizeformat` was called on a negative number: {num}"))
         })
         .map(to_value)
         .map(std::result::Result::unwrap)

--- a/src/builtins/filters/number.rs
+++ b/src/builtins/filters/number.rs
@@ -25,9 +25,9 @@ pub fn pluralize(value: &Value, args: &HashMap<String, Value>) -> Result<Value> 
 
     // English uses plural when it isn't one
     if (num.abs() - 1.).abs() > ::std::f64::EPSILON {
-        Ok(to_value(&plural).unwrap())
+        Ok(to_value(plural).unwrap())
     } else {
-        Ok(to_value(&singular).unwrap())
+        Ok(to_value(singular).unwrap())
     }
 }
 

--- a/src/builtins/filters/string.rs
+++ b/src/builtins/filters/string.rs
@@ -836,10 +836,10 @@ mod tests {
             assert_eq!(result.unwrap(), to_value(expected).unwrap());
         }
 
-        args.insert("default".to_string(), to_value(3.14).unwrap());
+        args.insert("default".to_string(), to_value(3.18).unwrap());
         let result = float(&to_value("bad_val").unwrap(), &args);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), to_value(3.14).unwrap());
+        assert_eq!(result.unwrap(), to_value(3.18).unwrap());
 
         let result = float(&to_value(1.23).unwrap(), &args);
         assert!(result.is_ok());

--- a/src/builtins/filters/string.rs
+++ b/src/builtins/filters/string.rs
@@ -249,7 +249,7 @@ pub fn title(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
     Ok(to_value(&WORDS_RE.replace_all(&s, |caps: &Captures| {
         let first = caps["first"].to_uppercase();
         let rest = caps["rest"].to_lowercase();
-        format!("{}{}", first, rest)
+        format!("{first}{rest}")
     }))
     .unwrap())
 }

--- a/src/builtins/filters/string.rs
+++ b/src/builtins/filters/string.rs
@@ -69,35 +69,35 @@ lazy_static! {
 pub fn upper(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
     let s = try_get_value!("upper", "value", String, value);
 
-    Ok(to_value(&s.to_uppercase()).unwrap())
+    Ok(to_value(s.to_uppercase()).unwrap())
 }
 
 /// Convert a value to lowercase.
 pub fn lower(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
     let s = try_get_value!("lower", "value", String, value);
 
-    Ok(to_value(&s.to_lowercase()).unwrap())
+    Ok(to_value(s.to_lowercase()).unwrap())
 }
 
 /// Strip leading and trailing whitespace.
 pub fn trim(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
     let s = try_get_value!("trim", "value", String, value);
 
-    Ok(to_value(&s.trim()).unwrap())
+    Ok(to_value(s.trim()).unwrap())
 }
 
 /// Strip leading whitespace.
 pub fn trim_start(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
     let s = try_get_value!("trim_start", "value", String, value);
 
-    Ok(to_value(&s.trim_start()).unwrap())
+    Ok(to_value(s.trim_start()).unwrap())
 }
 
 /// Strip trailing whitespace.
 pub fn trim_end(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
     let s = try_get_value!("trim_end", "value", String, value);
 
-    Ok(to_value(&s.trim_end()).unwrap())
+    Ok(to_value(s.trim_end()).unwrap())
 }
 
 /// Strip leading characters that match the given pattern.
@@ -173,14 +173,14 @@ pub fn truncate(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
     }
 
     let result = s[..graphemes[length].0].to_string() + &end;
-    Ok(to_value(&result).unwrap())
+    Ok(to_value(result).unwrap())
 }
 
 /// Gets the number of words in a string.
 pub fn wordcount(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
     let s = try_get_value!("wordcount", "value", String, value);
 
-    Ok(to_value(&s.split_whitespace().count()).unwrap())
+    Ok(to_value(s.split_whitespace().count()).unwrap())
 }
 
 /// Replaces given `from` substring with `to` string.
@@ -197,7 +197,7 @@ pub fn replace(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
         None => return Err(Error::msg("Filter `replace` expected an arg called `to`")),
     };
 
-    Ok(to_value(&s.replace(&from, &to)).unwrap())
+    Ok(to_value(s.replace(&from, &to)).unwrap())
 }
 
 /// First letter of the string is uppercase rest is lowercase
@@ -208,7 +208,7 @@ pub fn capitalize(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
         None => Ok(to_value("").unwrap()),
         Some(f) => {
             let res = f.to_uppercase().collect::<String>() + &chars.as_str().to_lowercase();
-            Ok(to_value(&res).unwrap())
+            Ok(to_value(res).unwrap())
         }
     }
 }
@@ -217,7 +217,7 @@ pub fn capitalize(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
 #[cfg(feature = "urlencode")]
 pub fn urlencode(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
     let s = try_get_value!("urlencode", "value", String, value);
-    let encoded = percent_encode(s.as_bytes(), &PYTHON_ENCODE_SET).to_string();
+    let encoded = percent_encode(s.as_bytes(), PYTHON_ENCODE_SET).to_string();
     Ok(Value::String(encoded))
 }
 
@@ -225,28 +225,28 @@ pub fn urlencode(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
 #[cfg(feature = "urlencode")]
 pub fn urlencode_strict(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
     let s = try_get_value!("urlencode_strict", "value", String, value);
-    let encoded = percent_encode(s.as_bytes(), &NON_ALPHANUMERIC).to_string();
+    let encoded = percent_encode(s.as_bytes(), NON_ALPHANUMERIC).to_string();
     Ok(Value::String(encoded))
 }
 
 /// Escapes quote characters
 pub fn addslashes(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
     let s = try_get_value!("addslashes", "value", String, value);
-    Ok(to_value(&s.replace("\\", "\\\\").replace("\"", "\\\"").replace("\'", "\\\'")).unwrap())
+    Ok(to_value(s.replace("\\", "\\\\").replace("\"", "\\\"").replace("\'", "\\\'")).unwrap())
 }
 
 /// Transform a string into a slug
 #[cfg(feature = "builtins")]
 pub fn slugify(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
     let s = try_get_value!("slugify", "value", String, value);
-    Ok(to_value(&slug::slugify(s)).unwrap())
+    Ok(to_value(slug::slugify(s)).unwrap())
 }
 
 /// Capitalizes each word in the string
 pub fn title(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
     let s = try_get_value!("title", "value", String, value);
 
-    Ok(to_value(&WORDS_RE.replace_all(&s, |caps: &Captures| {
+    Ok(to_value(WORDS_RE.replace_all(&s, |caps: &Captures| {
         let first = caps["first"].to_uppercase();
         let rest = caps["rest"].to_lowercase();
         format!("{first}{rest}")
@@ -259,19 +259,19 @@ pub fn title(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
 /// Example: The input "Hello\nWorld" turns into "Hello<br>World".
 pub fn linebreaksbr(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
     let s = try_get_value!("title", "value", String, value);
-    Ok(to_value(&s.replace("\r\n", "<br>").replace("\n", "<br>")).unwrap())
+    Ok(to_value(s.replace("\r\n", "<br>").replace("\n", "<br>")).unwrap())
 }
 
 /// Removes html tags from string
 pub fn striptags(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
     let s = try_get_value!("striptags", "value", String, value);
-    Ok(to_value(&STRIPTAGS_RE.replace_all(&s, "")).unwrap())
+    Ok(to_value(STRIPTAGS_RE.replace_all(&s, "")).unwrap())
 }
 
 /// Removes spaces between html tags from string
 pub fn spaceless(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
     let s = try_get_value!("spaceless", "value", String, value);
-    Ok(to_value(&SPACELESS_RE.replace_all(&s, "><")).unwrap())
+    Ok(to_value(SPACELESS_RE.replace_all(&s, "><")).unwrap())
 }
 
 /// Returns the given text with all special HTML characters encoded
@@ -407,7 +407,7 @@ mod tests {
 
     #[test]
     fn test_upper_error() {
-        let result = upper(&to_value(&50).unwrap(), &HashMap::new());
+        let result = upper(&to_value(50).unwrap(), &HashMap::new());
         assert!(result.is_err());
         assert_eq!(
             result.err().unwrap().to_string(),
@@ -471,7 +471,7 @@ mod tests {
     #[test]
     fn test_truncate_smaller_than_length() {
         let mut args = HashMap::new();
-        args.insert("length".to_string(), to_value(&255).unwrap());
+        args.insert("length".to_string(), to_value(255).unwrap());
         let result = truncate(&to_value("hello").unwrap(), &args);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), to_value("hello").unwrap());
@@ -480,7 +480,7 @@ mod tests {
     #[test]
     fn test_truncate_when_required() {
         let mut args = HashMap::new();
-        args.insert("length".to_string(), to_value(&2).unwrap());
+        args.insert("length".to_string(), to_value(2).unwrap());
         let result = truncate(&to_value("日本語").unwrap(), &args);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), to_value("日本…").unwrap());
@@ -489,8 +489,8 @@ mod tests {
     #[test]
     fn test_truncate_custom_end() {
         let mut args = HashMap::new();
-        args.insert("length".to_string(), to_value(&2).unwrap());
-        args.insert("end".to_string(), to_value(&"").unwrap());
+        args.insert("length".to_string(), to_value(2).unwrap());
+        args.insert("end".to_string(), to_value("").unwrap());
         let result = truncate(&to_value("日本語").unwrap(), &args);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), to_value("日本").unwrap());
@@ -499,8 +499,8 @@ mod tests {
     #[test]
     fn test_truncate_multichar_grapheme() {
         let mut args = HashMap::new();
-        args.insert("length".to_string(), to_value(&5).unwrap());
-        args.insert("end".to_string(), to_value(&"…").unwrap());
+        args.insert("length".to_string(), to_value(5).unwrap());
+        args.insert("end".to_string(), to_value("…").unwrap());
         let result = truncate(&to_value("👨‍👩‍👧‍👦 family").unwrap(), &args);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), to_value("👨‍👩‍👧‍👦 fam…").unwrap());
@@ -517,15 +517,15 @@ mod tests {
     fn test_wordcount() {
         let result = wordcount(&to_value("Joel is a slug").unwrap(), &HashMap::new());
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), to_value(&4).unwrap());
+        assert_eq!(result.unwrap(), to_value(4).unwrap());
     }
 
     #[test]
     fn test_replace() {
         let mut args = HashMap::new();
-        args.insert("from".to_string(), to_value(&"Hello").unwrap());
-        args.insert("to".to_string(), to_value(&"Goodbye").unwrap());
-        let result = replace(&to_value(&"Hello world!").unwrap(), &args);
+        args.insert("from".to_string(), to_value("Hello").unwrap());
+        args.insert("to".to_string(), to_value("Goodbye").unwrap());
+        let result = replace(&to_value("Hello world!").unwrap(), &args);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), to_value("Goodbye world!").unwrap());
     }
@@ -534,9 +534,9 @@ mod tests {
     #[test]
     fn test_replace_newline() {
         let mut args = HashMap::new();
-        args.insert("from".to_string(), to_value(&"\n").unwrap());
-        args.insert("to".to_string(), to_value(&"<br>").unwrap());
-        let result = replace(&to_value(&"Animal Alphabets\nB is for Bee-Eater").unwrap(), &args);
+        args.insert("from".to_string(), to_value("\n").unwrap());
+        args.insert("to".to_string(), to_value("<br>").unwrap());
+        let result = replace(&to_value("Animal Alphabets\nB is for Bee-Eater").unwrap(), &args);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), to_value("Animal Alphabets<br>B is for Bee-Eater").unwrap());
     }
@@ -544,8 +544,8 @@ mod tests {
     #[test]
     fn test_replace_missing_arg() {
         let mut args = HashMap::new();
-        args.insert("from".to_string(), to_value(&"Hello").unwrap());
-        let result = replace(&to_value(&"Hello world!").unwrap(), &args);
+        args.insert("from".to_string(), to_value("Hello").unwrap());
+        let result = replace(&to_value("Hello world!").unwrap(), &args);
         assert!(result.is_err());
         assert_eq!(
             result.err().unwrap().to_string(),

--- a/src/builtins/filters/string.rs
+++ b/src/builtins/filters/string.rs
@@ -232,7 +232,7 @@ pub fn urlencode_strict(value: &Value, _: &HashMap<String, Value>) -> Result<Val
 /// Escapes quote characters
 pub fn addslashes(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
     let s = try_get_value!("addslashes", "value", String, value);
-    Ok(to_value(s.replace("\\", "\\\\").replace("\"", "\\\"").replace("\'", "\\\'")).unwrap())
+    Ok(to_value(s.replace('\\', "\\\\").replace('\"', "\\\"").replace('\'', "\\\'")).unwrap())
 }
 
 /// Transform a string into a slug
@@ -259,7 +259,7 @@ pub fn title(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
 /// Example: The input "Hello\nWorld" turns into "Hello<br>World".
 pub fn linebreaksbr(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
     let s = try_get_value!("title", "value", String, value);
-    Ok(to_value(s.replace("\r\n", "<br>").replace("\n", "<br>")).unwrap())
+    Ok(to_value(s.replace("\r\n", "<br>").replace('\n', "<br>")).unwrap())
 }
 
 /// Removes html tags from string

--- a/src/builtins/functions.rs
+++ b/src/builtins/functions.rs
@@ -238,7 +238,7 @@ mod tests {
 
         let res = now(&args).unwrap();
         assert!(res.is_string());
-        assert!(res.as_str().unwrap().contains("T"));
+        assert!(res.as_str().unwrap().contains('T'));
     }
 
     #[cfg(feature = "builtins")]
@@ -251,7 +251,7 @@ mod tests {
         assert!(res.is_string());
         let val = res.as_str().unwrap();
         println!("{val}");
-        assert!(val.contains("T"));
+        assert!(val.contains('T'));
         assert!(val.contains("+00:00"));
     }
 

--- a/src/builtins/functions.rs
+++ b/src/builtins/functions.rs
@@ -34,8 +34,7 @@ pub fn range(args: &HashMap<String, Value>) -> Result<Value> {
             Ok(v) => v,
             Err(_) => {
                 return Err(Error::msg(format!(
-                    "Function `range` received start={} but `start` can only be a number",
-                    val
+                    "Function `range` received start={val} but `start` can only be a number"
                 )));
             }
         },
@@ -46,8 +45,7 @@ pub fn range(args: &HashMap<String, Value>) -> Result<Value> {
             Ok(v) => v,
             Err(_) => {
                 return Err(Error::msg(format!(
-                    "Function `range` received step_by={} but `step` can only be a number",
-                    val
+                    "Function `range` received step_by={val} but `step` can only be a number"
                 )));
             }
         },
@@ -58,8 +56,7 @@ pub fn range(args: &HashMap<String, Value>) -> Result<Value> {
             Ok(v) => v,
             Err(_) => {
                 return Err(Error::msg(format!(
-                    "Function `range` received end={} but `end` can only be a number",
-                    val
+                    "Function `range` received end={val} but `end` can only be a number"
                 )));
             }
         },
@@ -90,8 +87,7 @@ pub fn now(args: &HashMap<String, Value>) -> Result<Value> {
             Ok(v) => v,
             Err(_) => {
                 return Err(Error::msg(format!(
-                    "Function `now` received utc={} but `utc` can only be a boolean",
-                    val
+                    "Function `now` received utc={val} but `utc` can only be a boolean"
                 )));
             }
         },
@@ -102,8 +98,7 @@ pub fn now(args: &HashMap<String, Value>) -> Result<Value> {
             Ok(v) => v,
             Err(_) => {
                 return Err(Error::msg(format!(
-                    "Function `now` received timestamp={} but `timestamp` can only be a boolean",
-                    val
+                    "Function `now` received timestamp={val} but `timestamp` can only be a boolean"
                 )));
             }
         },
@@ -130,8 +125,7 @@ pub fn throw(args: &HashMap<String, Value>) -> Result<Value> {
         Some(val) => match from_value::<String>(val.clone()) {
             Ok(v) => Err(Error::msg(v)),
             Err(_) => Err(Error::msg(format!(
-                "Function `throw` received message={} but `message` can only be a string",
-                val
+                "Function `throw` received message={val} but `message` can only be a string"
             ))),
         },
         None => Err(Error::msg("Function `throw` was called without a `message` argument")),
@@ -145,8 +139,7 @@ pub fn get_random(args: &HashMap<String, Value>) -> Result<Value> {
             Ok(v) => v,
             Err(_) => {
                 return Err(Error::msg(format!(
-                    "Function `get_random` received start={} but `start` can only be a number",
-                    val
+                    "Function `get_random` received start={val} but `start` can only be a number"
                 )));
             }
         },
@@ -158,8 +151,7 @@ pub fn get_random(args: &HashMap<String, Value>) -> Result<Value> {
             Ok(v) => v,
             Err(_) => {
                 return Err(Error::msg(format!(
-                    "Function `get_random` received end={} but `end` can only be a number",
-                    val
+                    "Function `get_random` received end={val} but `end` can only be a number"
                 )));
             }
         },
@@ -177,8 +169,7 @@ pub fn get_env(args: &HashMap<String, Value>) -> Result<Value> {
             Ok(v) => v,
             Err(_) => {
                 return Err(Error::msg(format!(
-                    "Function `get_env` received name={} but `name` can only be a string",
-                    val
+                    "Function `get_env` received name={val} but `name` can only be a string"
                 )));
             }
         },
@@ -259,7 +250,7 @@ mod tests {
         let res = now(&args).unwrap();
         assert!(res.is_string());
         let val = res.as_str().unwrap();
-        println!("{}", val);
+        println!("{val}");
         assert!(val.contains("T"));
         assert!(val.contains("+00:00"));
     }
@@ -291,7 +282,7 @@ mod tests {
         let mut args = HashMap::new();
         args.insert("end".to_string(), to_value(10).unwrap());
         let res = get_random(&args).unwrap();
-        println!("{}", res);
+        println!("{res}");
         assert!(res.is_number());
         assert!(res.as_i64().unwrap() >= 0);
         assert!(res.as_i64().unwrap() < 10);
@@ -304,7 +295,7 @@ mod tests {
         args.insert("start".to_string(), to_value(5).unwrap());
         args.insert("end".to_string(), to_value(10).unwrap());
         let res = get_random(&args).unwrap();
-        println!("{}", res);
+        println!("{res}");
         assert!(res.is_number());
         assert!(res.as_i64().unwrap() >= 5);
         assert!(res.as_i64().unwrap() < 10);

--- a/src/builtins/testers.rs
+++ b/src/builtins/testers.rs
@@ -225,12 +225,12 @@ mod tests {
 
     #[test]
     fn test_number_args_ok() {
-        assert!(defined(None, &vec![]).is_ok())
+        assert!(defined(None, &[]).is_ok())
     }
 
     #[test]
     fn test_too_many_args() {
-        assert!(defined(None, &vec![to_value(1).unwrap()]).is_err())
+        assert!(defined(None, &[to_value(1).unwrap()]).is_err())
     }
 
     #[test]

--- a/src/builtins/testers.rs
+++ b/src/builtins/testers.rs
@@ -22,15 +22,13 @@ where
 pub fn number_args_allowed(tester_name: &str, max: usize, args_len: usize) -> Result<()> {
     if max == 0 && args_len > max {
         return Err(Error::msg(format!(
-            "Tester `{}` was called with some args but this test doesn't take args",
-            tester_name
+            "Tester `{tester_name}` was called with some args but this test doesn't take args"
         )));
     }
 
     if args_len > max {
         return Err(Error::msg(format!(
-            "Tester `{}` was called with {} args, the max number is {}",
-            tester_name, args_len, max
+            "Tester `{tester_name}` was called with {args_len} args, the max number is {max}"
         )));
     }
 
@@ -41,8 +39,7 @@ pub fn number_args_allowed(tester_name: &str, max: usize, args_len: usize) -> Re
 pub fn value_defined(tester_name: &str, value: Option<&Value>) -> Result<()> {
     if value.is_none() {
         return Err(Error::msg(format!(
-            "Tester `{}` was called on an undefined variable",
-            tester_name
+            "Tester `{tester_name}` was called on an undefined variable"
         )));
     }
 
@@ -59,8 +56,7 @@ pub fn extract_string<'a>(
     match value.and_then(Value::as_str) {
         Some(s) => Ok(s),
         None => Err(Error::msg(format!(
-            "Tester `{}` was called {} that isn't a string",
-            tester_name, part
+            "Tester `{tester_name}` was called {part} that isn't a string"
         ))),
     }
 }
@@ -208,8 +204,7 @@ pub fn matching(value: Option<&Value>, params: &[Value]) -> Result<bool> {
         Ok(regex) => regex,
         Err(err) => {
             return Err(Error::msg(format!(
-                "Tester `matching`: Invalid regular expression: {}",
-                err
+                "Tester `matching`: Invalid regular expression: {err}"
             )));
         }
     };

--- a/src/builtins/testers.rs
+++ b/src/builtins/testers.rs
@@ -55,9 +55,9 @@ pub fn extract_string<'a>(
 ) -> Result<&'a str> {
     match value.and_then(Value::as_str) {
         Some(s) => Ok(s),
-        None => Err(Error::msg(format!(
-            "Tester `{tester_name}` was called {part} that isn't a string"
-        ))),
+        None => {
+            Err(Error::msg(format!("Tester `{tester_name}` was called {part} that isn't a string")))
+        }
     }
 }
 
@@ -259,18 +259,18 @@ mod tests {
 
     #[test]
     fn test_iterable() {
-        assert_eq!(iterable(Some(&to_value(vec!["1"]).unwrap()), &[]).unwrap(), true);
-        assert_eq!(iterable(Some(&to_value(1).unwrap()), &[]).unwrap(), false);
-        assert_eq!(iterable(Some(&to_value("hello").unwrap()), &[]).unwrap(), false);
+        assert!(iterable(Some(&to_value(vec!["1"]).unwrap()), &[]).unwrap());
+        assert!(!iterable(Some(&to_value(1).unwrap()), &[]).unwrap());
+        assert!(!iterable(Some(&to_value("hello").unwrap()), &[]).unwrap());
     }
 
     #[test]
     fn test_object() {
         let mut h = HashMap::new();
         h.insert("a", 1);
-        assert_eq!(object(Some(&to_value(h).unwrap()), &[]).unwrap(), true);
-        assert_eq!(object(Some(&to_value(1).unwrap()), &[]).unwrap(), false);
-        assert_eq!(object(Some(&to_value("hello").unwrap()), &[]).unwrap(), false);
+        assert!(object(Some(&to_value(h).unwrap()), &[]).unwrap());
+        assert!(!object(Some(&to_value(1).unwrap()), &[]).unwrap());
+        assert!(!object(Some(&to_value("hello").unwrap()), &[]).unwrap());
     }
 
     #[test]

--- a/src/context.rs
+++ b/src/context.rs
@@ -143,19 +143,19 @@ pub trait ValueRender {
 impl ValueRender for Value {
     fn render(&self, write: &mut impl Write) -> std::io::Result<()> {
         match *self {
-            Value::String(ref s) => write!(write, "{}", s),
+            Value::String(ref s) => write!(write, "{s}"),
             Value::Number(ref i) => {
                 if let Some(v) = i.as_i64() {
-                    write!(write, "{}", v)
+                    write!(write, "{v}")
                 } else if let Some(v) = i.as_u64() {
-                    write!(write, "{}", v)
+                    write!(write, "{v}")
                 } else if let Some(v) = i.as_f64() {
-                    write!(write, "{}", v)
+                    write!(write, "{v}")
                 } else {
                     unreachable!()
                 }
             }
-            Value::Bool(i) => write!(write, "{}", i),
+            Value::Bool(i) => write!(write, "{i}"),
             Value::Null => Ok(()),
             Value::Array(ref a) => {
                 let mut first = true;

--- a/src/context.rs
+++ b/src/context.rs
@@ -231,7 +231,7 @@ pub fn get_json_pointer(key: &str) -> String {
             .collect();
         segments.join("/")
     } else {
-        ["/", &key.replace(".", "/")].join("")
+        ["/", &key.replace('.', "/")].join("")
     }
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -88,7 +88,6 @@ impl fmt::Display for Error {
             ErrorKind::Utf8Conversion { ref context } => {
                 write!(f, "UTF-8 conversion error occured while rendering template: {context}")
             }
-            _ => write!(f, "Nonexhaustive"),
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -4,6 +4,7 @@ use std::fmt;
 
 /// The kind of an error (non-exhaustive)
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum ErrorKind {
     /// Generic error
     Msg(String),
@@ -48,11 +49,6 @@ pub enum ErrorKind {
         /// The context that indicates where the error occurs in the rendering process
         context: String,
     },
-    /// This enum may grow additional variants, so this makes sure clients
-    /// don't count on exhaustive matching. (Otherwise, adding a new variant
-    /// could break existing code.)
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 /// The Error type
@@ -92,7 +88,7 @@ impl fmt::Display for Error {
             ErrorKind::Utf8Conversion { ref context } => {
                 write!(f, "UTF-8 conversion error occured while rendering template: {context}")
             }
-            ErrorKind::__Nonexhaustive => write!(f, "Nonexhaustive"),
+            _ => write!(f, "Nonexhaustive"),
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -66,33 +66,31 @@ pub struct Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.kind {
-            ErrorKind::Msg(ref message) => write!(f, "{}", message),
+            ErrorKind::Msg(ref message) => write!(f, "{message}"),
             ErrorKind::CircularExtend { ref tpl, ref inheritance_chain } => write!(
                 f,
-                "Circular extend detected for template '{}'. Inheritance chain: `{:?}`",
-                tpl, inheritance_chain
+                "Circular extend detected for template '{tpl}'. Inheritance chain: `{inheritance_chain:?}`"
             ),
             ErrorKind::MissingParent { ref current, ref parent } => write!(
                 f,
-                "Template '{}' is inheriting from '{}', which doesn't exist or isn't loaded.",
-                current, parent
+                "Template '{current}' is inheriting from '{parent}', which doesn't exist or isn't loaded."
             ),
-            ErrorKind::TemplateNotFound(ref name) => write!(f, "Template '{}' not found", name),
-            ErrorKind::FilterNotFound(ref name) => write!(f, "Filter '{}' not found", name),
-            ErrorKind::TestNotFound(ref name) => write!(f, "Test '{}' not found", name),
-            ErrorKind::FunctionNotFound(ref name) => write!(f, "Function '{}' not found", name),
+            ErrorKind::TemplateNotFound(ref name) => write!(f, "Template '{name}' not found"),
+            ErrorKind::FilterNotFound(ref name) => write!(f, "Filter '{name}' not found"),
+            ErrorKind::TestNotFound(ref name) => write!(f, "Test '{name}' not found"),
+            ErrorKind::FunctionNotFound(ref name) => write!(f, "Function '{name}' not found"),
             ErrorKind::InvalidMacroDefinition(ref info) => {
-                write!(f, "Invalid macro definition: `{}`", info)
+                write!(f, "Invalid macro definition: `{info}`")
             }
-            ErrorKind::Json(ref e) => write!(f, "{}", e),
-            ErrorKind::CallFunction(ref name) => write!(f, "Function call '{}' failed", name),
-            ErrorKind::CallFilter(ref name) => write!(f, "Filter call '{}' failed", name),
-            ErrorKind::CallTest(ref name) => write!(f, "Test call '{}' failed", name),
+            ErrorKind::Json(ref e) => write!(f, "{e}"),
+            ErrorKind::CallFunction(ref name) => write!(f, "Function call '{name}' failed"),
+            ErrorKind::CallFilter(ref name) => write!(f, "Filter call '{name}' failed"),
+            ErrorKind::CallTest(ref name) => write!(f, "Test call '{name}' failed"),
             ErrorKind::Io(ref io_error) => {
-                write!(f, "Io error while writing rendered value to output: {:?}", io_error)
+                write!(f, "Io error while writing rendered value to output: {io_error:?}")
             }
             ErrorKind::Utf8Conversion { ref context } => {
-                write!(f, "UTF-8 conversion error occured while rendering template: {}", context)
+                write!(f, "UTF-8 conversion error occured while rendering template: {context}")
             }
             ErrorKind::__Nonexhaustive => write!(f, "Nonexhaustive"),
         }

--- a/src/filter_utils.rs
+++ b/src/filter_utils.rs
@@ -10,7 +10,7 @@ impl OrderedF64 {
         if n.is_finite() {
             Ok(OrderedF64(n))
         } else {
-            Err(Error::msg(format!("{} cannot be sorted", n)))
+            Err(Error::msg(format!("{n} cannot be sorted")))
         }
     }
 }
@@ -39,27 +39,27 @@ pub trait GetValue: Ord + Sized + Clone {
 
 impl GetValue for OrderedF64 {
     fn get_value(val: &Value) -> Result<Self> {
-        let n = val.as_f64().ok_or_else(|| Error::msg(format!("expected number got {}", val)))?;
+        let n = val.as_f64().ok_or_else(|| Error::msg(format!("expected number got {val}")))?;
         OrderedF64::new(n)
     }
 }
 
 impl GetValue for i64 {
     fn get_value(val: &Value) -> Result<Self> {
-        val.as_i64().ok_or_else(|| Error::msg(format!("expected number got {}", val)))
+        val.as_i64().ok_or_else(|| Error::msg(format!("expected number got {val}")))
     }
 }
 
 impl GetValue for bool {
     fn get_value(val: &Value) -> Result<Self> {
-        val.as_bool().ok_or_else(|| Error::msg(format!("expected bool got {}", val)))
+        val.as_bool().ok_or_else(|| Error::msg(format!("expected bool got {val}")))
     }
 }
 
 impl GetValue for String {
     fn get_value(val: &Value) -> Result<Self> {
         let str: Result<&str> =
-            val.as_str().ok_or_else(|| Error::msg(format!("expected string got {}", val)));
+            val.as_str().ok_or_else(|| Error::msg(format!("expected string got {val}")));
         Ok(str?.to_owned())
     }
 }
@@ -67,7 +67,7 @@ impl GetValue for String {
 impl GetValue for ArrayLen {
     fn get_value(val: &Value) -> Result<Self> {
         let arr =
-            val.as_array().ok_or_else(|| Error::msg(format!("expected array got {}", val)))?;
+            val.as_array().ok_or_else(|| Error::msg(format!("expected array got {val}")))?;
         Ok(ArrayLen(arr.len()))
     }
 }

--- a/src/filter_utils.rs
+++ b/src/filter_utils.rs
@@ -2,7 +2,7 @@ use crate::errors::{Error, Result};
 use serde_json::Value;
 use std::cmp::Ordering;
 
-#[derive(PartialEq, PartialOrd, Default, Copy, Clone)]
+#[derive(PartialEq, Default, Copy, Clone)]
 pub struct OrderedF64(f64);
 
 impl OrderedF64 {
@@ -21,6 +21,12 @@ impl Ord for OrderedF64 {
     fn cmp(&self, other: &OrderedF64) -> Ordering {
         // unwrap is safe because self.0 is finite.
         self.partial_cmp(other).unwrap()
+    }
+}
+
+impl PartialOrd for OrderedF64 {
+    fn partial_cmp(&self, other: &OrderedF64) -> Option<Ordering> {
+       Some(self.cmp(other))
     }
 }
 

--- a/src/filter_utils.rs
+++ b/src/filter_utils.rs
@@ -26,7 +26,7 @@ impl Ord for OrderedF64 {
 
 impl PartialOrd for OrderedF64 {
     fn partial_cmp(&self, other: &OrderedF64) -> Option<Ordering> {
-       Some(self.cmp(other))
+        Some(self.cmp(other))
     }
 }
 
@@ -66,8 +66,7 @@ impl GetValue for String {
 
 impl GetValue for ArrayLen {
     fn get_value(val: &Value) -> Result<Self> {
-        let arr =
-            val.as_array().ok_or_else(|| Error::msg(format!("expected array got {val}")))?;
+        let arr = val.as_array().ok_or_else(|| Error::msg(format!("expected array got {val}")))?;
         Ok(ArrayLen(arr.len()))
     }
 }
@@ -114,10 +113,10 @@ pub fn get_sort_strategy_for_type(ty: &Value) -> Result<Box<dyn SortStrategy>> {
     use crate::Value::*;
     match *ty {
         Null => Err(Error::msg("Null is not a sortable value")),
-        Bool(_) => Ok(Box::new(SortBools::default())),
-        Number(_) => Ok(Box::new(SortNumbers::default())),
-        String(_) => Ok(Box::new(SortStrings::default())),
-        Array(_) => Ok(Box::new(SortArrays::default())),
+        Bool(_) => Ok(Box::<SortBools>::default()),
+        Number(_) => Ok(Box::<SortNumbers>::default()),
+        String(_) => Ok(Box::<SortStrings>::default()),
+        Array(_) => Ok(Box::<SortArrays>::default()),
         Object(_) => Err(Error::msg("Object is not a sortable value")),
     }
 }
@@ -167,12 +166,12 @@ pub fn get_unique_strategy_for_type(
     use crate::Value::*;
     match *ty {
         Null => Err(Error::msg("Null is not a unique value")),
-        Bool(_) => Ok(Box::new(UniqueBools::default())),
+        Bool(_) => Ok(Box::<UniqueBools>::default()),
         Number(ref val) => {
             if val.is_f64() {
                 Err(Error::msg("Unique floats are not implemented"))
             } else {
-                Ok(Box::new(UniqueNumbers::default()))
+                Ok(Box::<UniqueNumbers>::default())
             }
         }
         String(_) => Ok(Box::new(UniqueStrings::new(case_sensitive))),

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -130,7 +130,7 @@ impl StringConcat {
         let mut res = Vec::new();
         for value in &self.values {
             match value {
-                ExprVal::String(ref s) => res.push(format!("'{}'", s)),
+                ExprVal::String(ref s) => res.push(format!("'{s}'")),
                 ExprVal::Ident(ref s) => res.push(s.to_string()),
                 _ => res.push("unknown".to_string()),
             }

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -3,6 +3,7 @@ use std::fmt;
 
 /// Whether to remove the whitespace of a `{% %}` tag
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Default)]
 pub struct WS {
     /// `true` if the tag is `{%-`
     pub left: bool,
@@ -10,11 +11,7 @@ pub struct WS {
     pub right: bool,
 }
 
-impl Default for WS {
-    fn default() -> Self {
-        WS { left: false, right: false }
-    }
-}
+
 
 /// All math operators
 #[derive(Copy, Clone, Debug, PartialEq)]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -222,7 +222,7 @@ fn parse_string_concat(pair: Pair<Rule>) -> TeraResult<ExprVal> {
 }
 
 fn parse_basic_expression(pair: Pair<Rule>) -> TeraResult<ExprVal> {
-    let primary = |pair| parse_basic_expression(pair);
+    let primary = parse_basic_expression;
 
     let infix = |lhs: TeraResult<ExprVal>, op: Pair<Rule>, rhs: TeraResult<ExprVal>| {
         Ok(ExprVal::Math(MathExpr {
@@ -362,7 +362,7 @@ fn parse_in_condition(pair: Pair<Rule>) -> TeraResult<Expr> {
 
 /// A basic expression with optional filters with prece
 fn parse_comparison_val(pair: Pair<Rule>) -> TeraResult<Expr> {
-    let primary = |pair| parse_comparison_val(pair);
+    let primary = parse_comparison_val;
 
     let infix = |lhs: TeraResult<Expr>, op: Pair<Rule>, rhs: TeraResult<Expr>| {
         Ok(Expr::new(ExprVal::Math(MathExpr {
@@ -388,7 +388,7 @@ fn parse_comparison_val(pair: Pair<Rule>) -> TeraResult<Expr> {
 }
 
 fn parse_comparison_expression(pair: Pair<Rule>) -> TeraResult<Expr> {
-    let primary = |pair| parse_comparison_expression(pair);
+    let primary = parse_comparison_expression;
 
     let infix = |lhs: TeraResult<Expr>, op: Pair<Rule>, rhs: TeraResult<Expr>| {
         Ok(Expr::new(ExprVal::Logic(LogicExpr {
@@ -438,7 +438,7 @@ fn parse_logic_val(pair: Pair<Rule>) -> TeraResult<Expr> {
 }
 
 fn parse_logic_expr(pair: Pair<Rule>) -> TeraResult<Expr> {
-    let primary = |pair: Pair<Rule>| parse_logic_expr(pair);
+    let primary = parse_logic_expr;
 
     let infix = |lhs: TeraResult<Expr>, op: Pair<Rule>, rhs: TeraResult<Expr>| match op.as_rule() {
         Rule::op_or => Ok(Expr::new(ExprVal::Logic(LogicExpr {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -765,7 +765,7 @@ fn parse_macro_arg(p: Pair<Rule>) -> TeraResult<ExprVal> {
             "False" => Some(ExprVal::Bool(false)),
             _ => unreachable!(),
         },
-        Rule::string => Some(ExprVal::String(replace_string_markers(&p.as_str()))),
+        Rule::string => Some(ExprVal::String(replace_string_markers(p.as_str()))),
         _ => unreachable!("Got {:?} in parse_macro_arg: {}", p.as_rule(), p.as_str()),
     };
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use lazy_static::lazy_static;
 use pest::iterators::Pair;
-use pest::prec_climber::{Assoc, Operator, PrecClimber};
+use pest::pratt_parser::{Assoc, Op, PrattParser};
 use pest::Parser;
 use pest_derive::Parser;
 
@@ -27,24 +27,20 @@ use self::ast::*;
 pub use self::whitespace::remove_whitespace;
 
 lazy_static! {
-    static ref MATH_CLIMBER: PrecClimber<Rule> = PrecClimber::new(vec![
-        // +, -
-        Operator::new(Rule::op_plus, Assoc::Left) | Operator::new(Rule::op_minus, Assoc::Left),
-        // *, /, %
-        Operator::new(Rule::op_times, Assoc::Left) |
-        Operator::new(Rule::op_slash, Assoc::Left) |
-        Operator::new(Rule::op_modulo, Assoc::Left),
-    ]);
-    static ref COMPARISON_EXPR_CLIMBER: PrecClimber<Rule> = PrecClimber::new(vec![
-        // <, <=, >, >=, ==, !=
-        Operator::new(Rule::op_lt, Assoc::Left) | Operator::new(Rule::op_lte, Assoc::Left)
-        | Operator::new(Rule::op_gt, Assoc::Left) | Operator::new(Rule::op_gte, Assoc::Left)
-        | Operator::new(Rule::op_eq, Assoc::Left) | Operator::new(Rule::op_ineq, Assoc::Left),
-    ]);
-    static ref LOGIC_EXPR_CLIMBER: PrecClimber<Rule> = PrecClimber::new(vec![
-        Operator::new(Rule::op_or, Assoc::Left),
-        Operator::new(Rule::op_and, Assoc::Left),
-    ]);
+
+    static ref MATH_PARSER: PrattParser<Rule> = PrattParser::new()
+        .op(Op::infix(Rule::op_plus, Assoc::Left) | Op::infix(Rule::op_minus, Assoc::Left)) // +, -
+        .op(Op::infix(Rule::op_times, Assoc::Left)
+            | Op::infix(Rule::op_slash, Assoc::Left)
+            | Op::infix(Rule::op_modulo, Assoc::Left)); // *, /, %
+
+    static ref COMPARISON_EXPR_PARSER: PrattParser<Rule> = PrattParser::new()
+        .op(Op::infix(Rule::op_lt, Assoc::Left) | Op::infix(Rule::op_lte, Assoc::Left) | Op::infix(Rule::op_gt, Assoc::Left)
+            | Op::infix(Rule::op_gte, Assoc::Left)
+            | Op::infix(Rule::op_eq, Assoc::Left)| Op::infix(Rule::op_ineq, Assoc::Left)); // <, <=, >, >=, ==, !=
+
+    static ref LOGIC_EXPR_PARSER: PrattParser<Rule> = PrattParser::new()
+        .op(Op::infix(Rule::op_or, Assoc::Left)).op(Op::infix(Rule::op_and, Assoc::Left));
 }
 
 /// Strings are delimited by double quotes, single quotes and backticks
@@ -266,7 +262,9 @@ fn parse_basic_expression(pair: Pair<Rule>) -> TeraResult<ExprVal> {
         Rule::fn_call => ExprVal::FunctionCall(parse_fn_call(pair)?),
         Rule::macro_call => ExprVal::MacroCall(parse_macro_call(pair)?),
         Rule::dotted_square_bracket_ident => ExprVal::Ident(pair.as_str().to_string()),
-        Rule::basic_expr => MATH_CLIMBER.climb(pair.into_inner(), primary, infix)?,
+        Rule::basic_expr => {
+            MATH_PARSER.map_primary(primary).map_infix(infix).parse(pair.into_inner())?
+        }
         _ => unreachable!("Got {:?} in parse_basic_expression: {}", pair.as_rule(), pair.as_str()),
     };
     Ok(expr)
@@ -381,7 +379,7 @@ fn parse_comparison_val(pair: Pair<Rule>) -> TeraResult<Expr> {
 
     let expr = match pair.as_rule() {
         Rule::basic_expr_filter => parse_basic_expr_with_filters(pair)?,
-        Rule::comparison_val => MATH_CLIMBER.climb(pair.into_inner(), primary, infix)?,
+        Rule::comparison_val => MATH_PARSER.map_primary(primary).map_infix(infix).parse(pair.into_inner())?,
         _ => unreachable!("Got {:?} in parse_comparison_val", pair.as_rule()),
     };
     Ok(expr)
@@ -410,7 +408,7 @@ fn parse_comparison_expression(pair: Pair<Rule>) -> TeraResult<Expr> {
         Rule::comparison_val => parse_comparison_val(pair)?,
         Rule::string_expr_filter => parse_string_expr_with_filters(pair)?,
         Rule::comparison_expr => {
-            COMPARISON_EXPR_CLIMBER.climb(pair.into_inner(), primary, infix)?
+            COMPARISON_EXPR_PARSER.map_primary(primary).map_infix(infix).parse(pair.into_inner())?
         }
         _ => unreachable!("Got {:?} in parse_comparison_expression", pair.as_rule()),
     };
@@ -459,7 +457,9 @@ fn parse_logic_expr(pair: Pair<Rule>) -> TeraResult<Expr> {
 
     let expr = match pair.as_rule() {
         Rule::logic_val => parse_logic_val(pair)?,
-        Rule::logic_expr => LOGIC_EXPR_CLIMBER.climb(pair.into_inner(), primary, infix)?,
+        Rule::logic_expr => {
+            LOGIC_EXPR_PARSER.map_primary(primary).map_infix(infix).parse(pair.into_inner())?
+        }
         _ => unreachable!("Got {:?} in parse_logic_expr", pair.as_rule()),
     };
     Ok(expr)

--- a/src/parser/tests/errors.rs
+++ b/src/parser/tests/errors.rs
@@ -5,10 +5,10 @@ fn assert_err_msg(input: &str, needles: &[&str]) {
     assert!(res.is_err());
     let err = res.unwrap_err();
     let err_msg = err.to_string();
-    println!("{}", err_msg);
+    println!("{err_msg}");
     println!("Looking for:");
     for needle in needles {
-        println!("{}", needle);
+        println!("{needle}");
         assert!(err_msg.contains(needle));
     }
 }

--- a/src/parser/tests/lexer.rs
+++ b/src/parser/tests/lexer.rs
@@ -682,7 +682,7 @@ fn lex_requires_whitespace_between_things() {
 
     for i in inputs {
         let res = TeraParser::parse(Rule::template, i);
-        println!("{:?}", i);
+        println!("{i:?}");
         assert!(res.is_err());
     }
 }

--- a/src/parser/tests/parser.rs
+++ b/src/parser/tests/parser.rs
@@ -730,10 +730,8 @@ fn parse_set_global_tag() {
 #[test]
 fn parse_raw_tag() {
     let ast = parse("{% raw -%}{{hey}}{%- endraw %}").unwrap();
-    let mut start_ws = WS::default();
-    start_ws.right = true;
-    let mut end_ws = WS::default();
-    end_ws.left = true;
+    let start_ws = WS { right: true, ..Default::default() };
+    let end_ws = WS { left: true, ..Default::default() };
 
     assert_eq!(ast[0], Node::Raw(start_ws, "{{hey}}".to_string(), end_ws));
 }
@@ -752,10 +750,8 @@ fn parse_raw_tag_with_ws() {
 #[test]
 fn parse_filter_section_without_args() {
     let ast = parse("{% filter upper -%}A{%- endfilter %}").unwrap();
-    let mut start_ws = WS::default();
-    start_ws.right = true;
-    let mut end_ws = WS::default();
-    end_ws.left = true;
+    let start_ws = WS { right: true, ..Default::default() };
+    let end_ws = WS { left: true, ..Default::default() };
 
     assert_eq!(
         ast[0],
@@ -773,10 +769,8 @@ fn parse_filter_section_without_args() {
 #[test]
 fn parse_filter_section_with_args() {
     let ast = parse("{% filter upper(attr=1) -%}A{%- endfilter %}").unwrap();
-    let mut start_ws = WS::default();
-    start_ws.right = true;
-    let mut end_ws = WS::default();
-    end_ws.left = true;
+    let start_ws = WS { right: true, ..Default::default() };
+    let end_ws = WS { left: true, ..Default::default() };
 
     let mut args = HashMap::new();
     args.insert("attr".to_string(), Expr::new(ExprVal::Int(1)));
@@ -819,8 +813,7 @@ fn parse_filter_section_preserves_ws() {
 fn parse_block() {
     let ast = parse("{% block hello %}{{super()}} hey{%- endblock hello %}").unwrap();
     let start_ws = WS::default();
-    let mut end_ws = WS::default();
-    end_ws.left = true;
+    let end_ws = WS { left: true, ..Default::default() };
 
     assert_eq!(
         ast[0],
@@ -864,8 +857,7 @@ fn parse_simple_macro_definition() {
 fn parse_value_forloop() {
     let ast = parse("{% for item in items | reverse %}A{%- endfor %}").unwrap();
     let start_ws = WS::default();
-    let mut end_ws = WS::default();
-    end_ws.left = true;
+    let end_ws = WS { left: true, ..Default::default() };
 
     assert_eq!(
         ast[0],
@@ -890,8 +882,7 @@ fn parse_value_forloop() {
 fn parse_key_value_forloop() {
     let ast = parse("{% for key, item in get_map() %}A{%- endfor %}").unwrap();
     let start_ws = WS::default();
-    let mut end_ws = WS::default();
-    end_ws.left = true;
+    let end_ws = WS { left: true, ..Default::default() };
 
     assert_eq!(
         ast[0],
@@ -916,8 +907,7 @@ fn parse_key_value_forloop() {
 fn parse_value_forloop_array() {
     let ast = parse("{% for item in [1,2,] %}A{%- endfor %}").unwrap();
     let start_ws = WS::default();
-    let mut end_ws = WS::default();
-    end_ws.left = true;
+    let end_ws = WS { left: true, ..Default::default() };
 
     assert_eq!(
         ast[0],
@@ -942,8 +932,7 @@ fn parse_value_forloop_array() {
 fn parse_value_forloop_array_with_filter() {
     let ast = parse("{% for item in [1,2,] | reverse %}A{%- endfor %}").unwrap();
     let start_ws = WS::default();
-    let mut end_ws = WS::default();
-    end_ws.left = true;
+    let end_ws = WS { left: true, ..Default::default() };
 
     assert_eq!(
         ast[0],
@@ -968,8 +957,7 @@ fn parse_value_forloop_array_with_filter() {
 fn parse_value_forloop_empty() {
     let ast = parse("{% for item in [1,2,] %}A{% else %}B{%- endfor %}").unwrap();
     let start_ws = WS::default();
-    let mut end_ws = WS::default();
-    end_ws.left = true;
+    let end_ws = WS { left: true, ..Default::default() };
 
     assert_eq!(
         ast[0],
@@ -993,11 +981,8 @@ fn parse_value_forloop_empty() {
 #[test]
 fn parse_if() {
     let ast = parse("{% if item or admin %}A {%- elif 1 > 2 %}B{% else -%} C{%- endif %}").unwrap();
-    let mut end_ws = WS::default();
-    end_ws.left = true;
-
-    let mut else_ws = WS::default();
-    else_ws.right = true;
+    let end_ws = WS { left: true, ..Default::default() };
+    let else_ws = WS { right: true, ..Default::default() };
 
     assert_eq!(
         ast[0],
@@ -1014,7 +999,7 @@ fn parse_if() {
                         vec![Node::Text("A ".to_string())],
                     ),
                     (
-                        end_ws.clone(),
+                        end_ws,
                         Expr::new(ExprVal::Logic(LogicExpr {
                             lhs: Box::new(Expr::new(ExprVal::Int(1))),
                             operator: LogicOperator::Gt,

--- a/src/parser/tests/parser.rs
+++ b/src/parser/tests/parser.rs
@@ -109,9 +109,9 @@ fn parse_variable_tag_ident_with_simple_filters() {
 
 #[test]
 fn parse_variable_tag_lit() {
-    let ast = parse("{{ 2 }}{{ 3.14 }}{{ \"hey\" }}{{ true }}").unwrap();
+    let ast = parse("{{ 2 }}{{ 3.18 }}{{ \"hey\" }}{{ true }}").unwrap();
     assert_eq!(ast[0], Node::VariableBlock(WS::default(), Expr::new(ExprVal::Int(2))));
-    assert_eq!(ast[1], Node::VariableBlock(WS::default(), Expr::new(ExprVal::Float(3.14))));
+    assert_eq!(ast[1], Node::VariableBlock(WS::default(), Expr::new(ExprVal::Float(3.18))));
     assert_eq!(
         ast[2],
         Node::VariableBlock(WS::default(), Expr::new(ExprVal::String("hey".to_string()))),

--- a/src/parser/tests/whitespace.rs
+++ b/src/parser/tests/whitespace.rs
@@ -17,7 +17,7 @@ fn remove_previous_ws_if_single_opening_tag_requires_it() {
     ];
 
     assert_eq!(
-        remove_whitespace(ast.clone(), None),
+        remove_whitespace(ast, None),
         vec![
             Node::Text("hey".to_string()), // it removed the trailing space
             Node::ImportMacro(ws, "hey ".to_string(), "ho".to_string()),
@@ -34,7 +34,7 @@ fn remove_next_ws_if_single_opening_tag_requires_it() {
     ];
 
     assert_eq!(
-        remove_whitespace(ast.clone(), None),
+        remove_whitespace(ast, None),
         vec![
             Node::ImportMacro(ws, "hey ".to_string(), "ho".to_string()),
             Node::Text("hey".to_string()), // it removed the leading space
@@ -50,7 +50,7 @@ fn handle_ws_both_sides_for_raw_tag() {
         vec![Node::Raw(start_ws, "  hey ".to_string(), end_ws), Node::Text("  hey".to_string())];
 
     assert_eq!(
-        remove_whitespace(ast.clone(), None),
+        remove_whitespace(ast, None),
         vec![
             // it removed only the space at the end
             Node::Raw(start_ws, "  hey".to_string(), end_ws),
@@ -78,7 +78,7 @@ fn handle_ws_both_sides_for_macro_definitions() {
     )];
 
     assert_eq!(
-        remove_whitespace(ast.clone(), None),
+        remove_whitespace(ast, None),
         vec![Node::MacroDefinition(
             start_ws,
             MacroDefinition {
@@ -112,7 +112,7 @@ fn handle_ws_both_sides_for_forloop_tag_and_remove_empty_node() {
     ];
 
     assert_eq!(
-        remove_whitespace(ast.clone(), None),
+        remove_whitespace(ast, None),
         vec![
             Node::Forloop(
                 start_ws,
@@ -163,7 +163,7 @@ fn handle_ws_for_if_nodes() {
     ];
 
     assert_eq!(
-        remove_whitespace(ast.clone(), None),
+        remove_whitespace(ast, None),
         vec![
             Node::Text("C".to_string()),
             Node::If(
@@ -229,7 +229,7 @@ fn handle_ws_for_if_nodes_with_else() {
     ];
 
     assert_eq!(
-        remove_whitespace(ast.clone(), None),
+        remove_whitespace(ast, None),
         vec![
             Node::Text("C".to_string()),
             Node::If(

--- a/src/renderer/call_stack.rs
+++ b/src/renderer/call_stack.rs
@@ -123,7 +123,7 @@ impl<'a> CallStack<'a> {
             return self
                 .context
                 .find_value_by_pointer(&get_json_pointer(key))
-                .map(|v| Cow::Borrowed(v));
+                .map(Cow::Borrowed);
         } else if let Some(value) = self.context.find_value(key) {
             return Some(Cow::Borrowed(value));
         }

--- a/src/renderer/macros.rs
+++ b/src/renderer/macros.rs
@@ -52,7 +52,7 @@ impl<'a> MacroCollection<'a> {
             macro_namespace_map.insert("self", (template_name, &template.macros));
         }
 
-        for &(ref filename, ref namespace) in &template.imported_macro_files {
+        for (filename, namespace) in &template.imported_macro_files {
             let macro_tpl = tera.get_template(filename)?;
             macro_namespace_map.insert(namespace, (filename, &macro_tpl.macros));
             self.add_macros_from_template(tera, macro_tpl)?;

--- a/src/renderer/macros.rs
+++ b/src/renderer/macros.rs
@@ -105,14 +105,12 @@ impl<'a> MacroCollection<'a> {
                 Ok(m)
             } else {
                 Err(Error::msg(format!(
-                    "Macro `{}::{}` not found in template `{}`",
-                    macro_namespace, macro_name, template_name
+                    "Macro `{macro_namespace}::{macro_name}` not found in template `{template_name}`"
                 )))
             }
         } else {
             Err(Error::msg(format!(
-                "Macro namespace `{}` was not found in template `{}`. Have you maybe forgotten to import it, or misspelled it?",
-                macro_namespace, template_name
+                "Macro namespace `{macro_namespace}` was not found in template `{template_name}`. Have you maybe forgotten to import it, or misspelled it?"
             )))
         }
     }

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -55,7 +55,7 @@ impl<'a> Renderer<'a> {
     /// Combines the context with the Template to write the end result to output
     pub fn render_to(&self, mut output: impl Write) -> Result<()> {
         let mut processor =
-            Processor::new(self.template, self.tera, &self.context, self.should_escape);
+            Processor::new(self.template, self.tera, self.context, self.should_escape);
 
         processor.render(&mut output)
     }

--- a/src/renderer/processor.rs
+++ b/src/renderer/processor.rs
@@ -31,19 +31,17 @@ fn evaluate_sub_variables<'a>(key: &str, call_stack: &CallStack<'a>) -> Result<S
         match process_path(sub_var.as_ref(), call_stack) {
             Err(e) => {
                 return Err(Error::msg(format!(
-                    "Variable {} can not be evaluated because: {}",
-                    key, e
+                    "Variable {key} can not be evaluated because: {e}"
                 )));
             }
             Ok(post_var) => {
                 let post_var_as_str = match *post_var {
-                    Value::String(ref s) => format!(r#""{}""#, s),
+                    Value::String(ref s) => format!(r#""{s}""#),
                     Value::Number(ref n) => n.to_string(),
                     _ => {
                         return Err(Error::msg(format!(
                             "Only variables evaluating to String or Number can be used as \
-                             index (`{}` of `{}`)",
-                            sub_var, key,
+                             index (`{sub_var}` of `{key}`)",
                         )));
                     }
                 };
@@ -180,8 +178,7 @@ impl<'a> Processor<'a> {
             Value::Array(_) => {
                 if for_loop.key.is_some() {
                     return Err(Error::msg(format!(
-                        "Tried to iterate using key value on variable `{}`, but it isn't an object/map",
-                        container_name,
+                        "Tried to iterate using key value on variable `{container_name}`, but it isn't an object/map",
                     )));
                 }
                 ForLoop::from_array(&for_loop.value, container_val)
@@ -189,8 +186,7 @@ impl<'a> Processor<'a> {
             Value::String(_) => {
                 if for_loop.key.is_some() {
                     return Err(Error::msg(format!(
-                        "Tried to iterate using key value on variable `{}`, but it isn't an object/map",
-                        container_name,
+                        "Tried to iterate using key value on variable `{container_name}`, but it isn't an object/map",
                     )));
                 }
                 ForLoop::from_string(&for_loop.value, container_val)
@@ -198,8 +194,7 @@ impl<'a> Processor<'a> {
             Value::Object(_) => {
                 if for_loop.key.is_none() {
                     return Err(Error::msg(format!(
-                        "Tried to iterate using key value on variable `{}`, but it is missing a key",
-                        container_name,
+                        "Tried to iterate using key value on variable `{container_name}`, but it is missing a key",
                     )));
                 }
                 match container_val {
@@ -215,8 +210,7 @@ impl<'a> Processor<'a> {
             }
             _ => {
                 return Err(Error::msg(format!(
-                    "Tried to iterate on a container (`{}`) that has a unsupported type",
-                    container_name,
+                    "Tried to iterate on a container (`{container_name}`) that has a unsupported type",
                 )));
             }
         };
@@ -312,8 +306,7 @@ impl<'a> Processor<'a> {
                 Value::String(ref s2) => s.contains(s2),
                 _ => {
                     return Err(Error::msg(format!(
-                        "Tried to check if {:?} is in a string, but it isn't a string",
-                        lhs
+                        "Tried to check if {lhs:?} is in a string, but it isn't a string"
                     )))
                 }
             },
@@ -321,8 +314,7 @@ impl<'a> Processor<'a> {
                 Value::String(ref s2) => map.contains_key(s2),
                 _ => {
                     return Err(Error::msg(format!(
-                        "Tried to check if {:?} is in a object, but it isn't a string",
-                        lhs
+                        "Tried to check if {lhs:?} is in a object, but it isn't a string"
                     )))
                 }
             },
@@ -357,14 +349,13 @@ impl<'a> Processor<'a> {
                 for s in &str_concat.values {
                     match *s {
                         ExprVal::String(ref v) => res.push_str(&v),
-                        ExprVal::Int(ref v) => res.push_str(&format!("{}", v)),
-                        ExprVal::Float(ref v) => res.push_str(&format!("{}", v)),
+                        ExprVal::Int(ref v) => res.push_str(&format!("{v}")),
+                        ExprVal::Float(ref v) => res.push_str(&format!("{v}")),
                         ExprVal::Ident(ref i) => match *self.lookup_ident(i)? {
                             Value::String(ref v) => res.push_str(&v),
                             Value::Number(ref v) => res.push_str(&v.to_string()),
                             _ => return Err(Error::msg(format!(
-                                "Tried to concat a value that is not a string or a number from ident {}",
-                                i
+                                "Tried to concat a value that is not a string or a number from ident {i}"
                             ))),
                         },
                         ExprVal::FunctionCall(ref fn_call) => match *self.eval_tera_fn_call(fn_call, &mut needs_escape)? {
@@ -708,8 +699,7 @@ impl<'a> Processor<'a> {
                     Some(Number::from_f64(v.as_f64().unwrap()).unwrap())
                 } else {
                     return Err(Error::msg(format!(
-                        "Variable `{}` was used in a math operation but is not a number",
-                        ident
+                        "Variable `{ident}` was used in a math operation but is not a number"
                     )));
                 }
             }
@@ -731,8 +721,7 @@ impl<'a> Processor<'a> {
                                 Some(s) => s,
                                 None => {
                                     return Err(Error::msg(format!(
-                                        "{} x {} results in an out of bounds i64",
-                                        ll, rr
+                                        "{ll} x {rr} results in an out of bounds i64"
                                     )));
                                 }
                             };
@@ -745,8 +734,7 @@ impl<'a> Processor<'a> {
                                 Some(s) => s,
                                 None => {
                                     return Err(Error::msg(format!(
-                                        "{} x {} results in an out of bounds u64",
-                                        ll, rr
+                                        "{ll} x {rr} results in an out of bounds u64"
                                     )));
                                 }
                             };
@@ -779,8 +767,7 @@ impl<'a> Processor<'a> {
                                 Some(s) => s,
                                 None => {
                                     return Err(Error::msg(format!(
-                                        "{} + {} results in an out of bounds i64",
-                                        ll, rr
+                                        "{ll} + {rr} results in an out of bounds i64"
                                     )));
                                 }
                             };
@@ -792,8 +779,7 @@ impl<'a> Processor<'a> {
                                 Some(s) => s,
                                 None => {
                                     return Err(Error::msg(format!(
-                                        "{} + {} results in an out of bounds u64",
-                                        ll, rr
+                                        "{ll} + {rr} results in an out of bounds u64"
                                     )));
                                 }
                             };
@@ -812,8 +798,7 @@ impl<'a> Processor<'a> {
                                 Some(s) => s,
                                 None => {
                                     return Err(Error::msg(format!(
-                                        "{} - {} results in an out of bounds i64",
-                                        ll, rr
+                                        "{ll} - {rr} results in an out of bounds i64"
                                     )));
                                 }
                             };
@@ -825,8 +810,7 @@ impl<'a> Processor<'a> {
                                 Some(s) => s,
                                 None => {
                                     return Err(Error::msg(format!(
-                                        "{} - {} results in an out of bounds u64",
-                                        ll, rr
+                                        "{ll} - {rr} results in an out of bounds u64"
                                     )));
                                 }
                             };
@@ -843,8 +827,7 @@ impl<'a> Processor<'a> {
                             let rr = r.as_i64().unwrap();
                             if rr == 0 {
                                 return Err(Error::msg(format!(
-                                    "Tried to do a modulo by zero: {:?}/{:?}",
-                                    lhs, rhs
+                                    "Tried to do a modulo by zero: {lhs:?}/{rhs:?}"
                                 )));
                             }
                             Some(Number::from(ll % rr))
@@ -853,8 +836,7 @@ impl<'a> Processor<'a> {
                             let rr = r.as_u64().unwrap();
                             if rr == 0 {
                                 return Err(Error::msg(format!(
-                                    "Tried to do a modulo by zero: {:?}/{:?}",
-                                    lhs, rhs
+                                    "Tried to do a modulo by zero: {lhs:?}/{rhs:?}"
                                 )));
                             }
                             Some(Number::from(ll % rr))
@@ -882,10 +864,10 @@ impl<'a> Processor<'a> {
                 }
             }
             ExprVal::String(ref val) => {
-                return Err(Error::msg(format!("Tried to do math with a string: `{}`", val)));
+                return Err(Error::msg(format!("Tried to do math with a string: `{val}`")));
             }
             ExprVal::Bool(val) => {
-                return Err(Error::msg(format!("Tried to do math with a boolean: `{}`", val)));
+                return Err(Error::msg(format!("Tried to do math with a boolean: `{val}`")));
             }
             ExprVal::StringConcat(ref val) => {
                 return Err(Error::msg(format!(
@@ -959,7 +941,7 @@ impl<'a> Processor<'a> {
         match *node {
             // Comments are ignored when rendering
             Node::Comment(_, _) => (),
-            Node::Text(ref s) | Node::Raw(_, ref s, _) => write!(write, "{}", s)?,
+            Node::Text(ref s) | Node::Raw(_, ref s, _) => write!(write, "{s}")?,
             Node::VariableBlock(_, ref expr) => self.eval_expression(expr)?.render(write)?,
             Node::Set(_, ref set) => self.eval_set(set)?,
             Node::FilterSection(_, FilterSection { ref filter, ref body }, _) => {
@@ -969,7 +951,7 @@ impl<'a> Processor<'a> {
                 )?;
                 // the safe filter doesn't actually exist
                 if filter.name == "safe" {
-                    write!(write, "{}", body)?;
+                    write!(write, "{body}")?;
                 } else {
                     self.eval_filter(&Cow::Owned(Value::String(body)), filter, &mut false)?
                         .render(write)?;
@@ -1010,8 +992,7 @@ impl<'a> Processor<'a> {
             }
             Node::Extends(_, ref name) => {
                 return Err(Error::msg(format!(
-                    "Inheritance in included templates is currently not supported: extended `{}`",
-                    name
+                    "Inheritance in included templates is currently not supported: extended `{name}`"
                 )));
             }
             // TODO: make that a compile time error
@@ -1048,14 +1029,14 @@ impl<'a> Processor<'a> {
 
             if let Some(&(ref tpl_name, _)) = block_def {
                 if tpl_name != &self.template.name {
-                    error_location += &format!(" (error happened in '{}').", tpl_name);
+                    error_location += &format!(" (error happened in '{tpl_name}').");
                 }
             } else {
                 error_location += " (error happened in a parent template)";
             }
         } else if let Some(parent) = self.template.parents.last() {
             // Error happened in the base template, outside of blocks
-            error_location += &format!(" (error happened in '{}').", parent);
+            error_location += &format!(" (error happened in '{parent}').");
         }
 
         error_location

--- a/src/renderer/processor.rs
+++ b/src/renderer/processor.rs
@@ -22,7 +22,7 @@ static MAGICAL_DUMP_VAR: &str = "__tera_context";
 
 /// This will convert a Tera variable to a json pointer if it is possible by replacing
 /// the index with their evaluated stringified value
-fn evaluate_sub_variables<'a>(key: &str, call_stack: &CallStack<'a>) -> Result<String> {
+fn evaluate_sub_variables(key: &str, call_stack: &CallStack) -> Result<String> {
     let sub_vars_to_calc = pull_out_square_bracket(key);
     let mut new_key = key.to_string();
 
@@ -1019,11 +1019,8 @@ impl<'a> Processor<'a> {
 
         // which template are we in?
         if let Some(&(name, _template, ref level)) = self.blocks.last() {
-            let block_def = self
-                .template
-                .blocks_definitions
-                .get(&name.to_string())
-                .and_then(|b| b.get(*level));
+            let block_def =
+                self.template.blocks_definitions.get(&name.to_string()).and_then(|b| b.get(*level));
 
             if let Some((tpl_name, _)) = block_def {
                 if tpl_name != &self.template.name {

--- a/src/renderer/processor.rs
+++ b/src/renderer/processor.rs
@@ -60,13 +60,13 @@ fn evaluate_sub_variables<'a>(key: &str, call_stack: &CallStack<'a>) -> Result<S
     }
 
     Ok(new_key
-        .replace("/", "~1") // https://tools.ietf.org/html/rfc6901#section-3
+        .replace('/', "~1") // https://tools.ietf.org/html/rfc6901#section-3
         .replace("['", ".\"")
         .replace("[\"", ".\"")
-        .replace("[", ".")
+        .replace('[', ".")
         .replace("']", "\"")
         .replace("\"]", "\"")
-        .replace("]", ""))
+        .replace(']', ""))
 }
 
 fn process_path<'a>(path: &str, call_stack: &CallStack<'a>) -> Result<Val<'a>> {

--- a/src/renderer/processor.rs
+++ b/src/renderer/processor.rs
@@ -240,7 +240,7 @@ impl<'a> Processor<'a> {
     }
 
     fn render_if_node(&mut self, if_node: &'a If, write: &mut impl Write) -> Result<()> {
-        for &(_, ref expr, ref body) in &if_node.conditions {
+        for (_, expr, body) in &if_node.conditions {
             if self.eval_as_bool(expr)? {
                 return self.render_body(body, write);
             }
@@ -1027,7 +1027,7 @@ impl<'a> Processor<'a> {
                 .get(&name.to_string())
                 .and_then(|b| b.get(*level));
 
-            if let Some(&(ref tpl_name, _)) = block_def {
+            if let Some((tpl_name, _)) = block_def {
                 if tpl_name != &self.template.name {
                     error_location += &format!(" (error happened in '{tpl_name}').");
                 }

--- a/src/renderer/processor.rs
+++ b/src/renderer/processor.rs
@@ -751,12 +751,10 @@ impl<'a> Processor<'a> {
                         let res = ll / rr;
                         if res.is_nan() {
                             None
+                        } else if res.round() == res && res.is_finite() {
+                            Some(Number::from(res as i64))
                         } else {
-                            if res.round() == res && res.is_finite() {
-                                Some(Number::from(res as i64))
-                            } else {
-                                Number::from_f64(res)
-                            }
+                            Number::from_f64(res)
                         }
                     }
                     MathOperator::Add => {

--- a/src/renderer/stack_frame.rs
+++ b/src/renderer/stack_frame.rs
@@ -14,7 +14,7 @@ pub type FrameContext<'a> = HashMap<&'a str, Val<'a>>;
 #[inline]
 pub fn value_by_pointer<'a>(pointer: &str, val: &Val<'a>) -> Option<Val<'a>> {
     match *val {
-        Cow::Borrowed(r) => r.pointer(&get_json_pointer(pointer)).map(|found| Cow::Borrowed(found)),
+        Cow::Borrowed(r) => r.pointer(&get_json_pointer(pointer)).map(Cow::Borrowed),
         Cow::Owned(ref r) => {
             r.pointer(&get_json_pointer(pointer)).map(|found| Cow::Owned(found.clone()))
         }

--- a/src/renderer/tests/basic.rs
+++ b/src/renderer/tests/basic.rs
@@ -36,7 +36,7 @@ fn render_simple_string() {
 fn render_variable_block_lit_expr() {
     let inputs = vec![
         ("{{ 1 }}", "1"),
-        ("{{ 3.14 }}", "3.14"),
+        ("{{ 3.18 }}", "3.18"),
         ("{{ \"hey\" }}", "hey"),
         (r#"{{ "{{ hey }}" }}"#, "{{ hey }}"),
         ("{{ true }}", "true"),
@@ -696,21 +696,21 @@ fn can_do_string_concat() {
     context.insert("a_string", "hello");
     context.insert("another_string", "xXx");
     context.insert("an_int", &1);
-    context.insert("a_float", &3.14);
+    context.insert("a_float", &3.18);
 
     let inputs = vec![
         (r#"{{ "hello" ~ " world" }}"#, "hello world"),
         (r#"{{ "hello" ~ 1 }}"#, "hello1"),
-        (r#"{{ "hello" ~ 3.14 }}"#, "hello3.14"),
-        (r#"{{ 3.14 ~ "hello"}}"#, "3.14hello"),
+        (r#"{{ "hello" ~ 3.18 }}"#, "hello3.18"),
+        (r#"{{ 3.18 ~ "hello"}}"#, "3.18hello"),
         (r#"{{ "hello" ~ get_string() }}"#, "helloHello"),
         (r#"{{ get_string() ~ "hello" }}"#, "Hellohello"),
-        (r#"{{ get_string() ~ 3.14 }}"#, "Hello3.14"),
+        (r#"{{ get_string() ~ 3.18 }}"#, "Hello3.18"),
         (r#"{{ a_string ~ " world" }}"#, "hello world"),
         (r#"{{ a_string ~ ' world ' ~ another_string }}"#, "hello world xXx"),
         (r#"{{ a_string ~ another_string }}"#, "helloxXx"),
         (r#"{{ a_string ~ an_int }}"#, "hello1"),
-        (r#"{{ a_string ~ a_float }}"#, "hello3.14"),
+        (r#"{{ a_string ~ a_float }}"#, "hello3.18"),
     ];
 
     for (input, expected) in inputs {

--- a/src/renderer/tests/basic.rs
+++ b/src/renderer/tests/basic.rs
@@ -64,7 +64,7 @@ fn render_variable_block_lit_expr() {
     ];
 
     for (input, expected) in inputs {
-        println!("{:?} -> {:?}", input, expected);
+        println!("{input:?} -> {expected:?}");
         assert_eq!(render_template(input, &Context::new()).unwrap(), expected);
     }
 }
@@ -136,7 +136,7 @@ fn render_variable_block_ident() {
     ];
 
     for (input, expected) in inputs {
-        println!("{:?} -> {:?}", input, expected);
+        println!("{input:?} -> {expected:?}");
         assert_eq!(render_template(input, &context).unwrap(), expected);
     }
 }
@@ -191,7 +191,7 @@ fn render_variable_block_logic_expr() {
     ];
 
     for (input, expected) in inputs {
-        println!("{:?} -> {:?}", input, expected);
+        println!("{input:?} -> {expected:?}");
         assert_eq!(render_template(input, &context).unwrap(), expected);
     }
 }
@@ -227,7 +227,7 @@ fn comments_are_ignored() {
     ];
 
     for (input, expected) in inputs {
-        println!("{:?} -> {:?}", input, expected);
+        println!("{input:?} -> {expected:?}");
         assert_eq!(render_template(input, &Context::new()).unwrap(), expected);
     }
 }
@@ -323,7 +323,7 @@ fn render_raw_tag() {
     ];
 
     for (input, expected) in inputs {
-        println!("{:?} -> {:?}", input, expected);
+        println!("{input:?} -> {expected:?}");
         assert_eq!(render_template(input, &Context::new()).unwrap(), expected);
     }
 }
@@ -354,7 +354,7 @@ fn add_set_values_in_context() {
     ];
 
     for (input, expected) in inputs {
-        println!("{:?} -> {:?}", input, expected);
+        println!("{input:?} -> {expected:?}");
         assert_eq!(render_template(input, &context).unwrap(), expected);
     }
 }
@@ -375,7 +375,7 @@ fn render_filter_section() {
 
     let context = Context::new();
     for (input, expected) in inputs {
-        println!("{:?} -> {:?}", input, expected);
+        println!("{input:?} -> {expected:?}");
         assert_eq!(render_template(input, &context).unwrap(), expected);
     }
 }
@@ -412,7 +412,7 @@ fn render_tests() {
     ];
 
     for (input, expected) in inputs {
-        println!("{:?} -> {:?}", input, expected);
+        println!("{input:?} -> {expected:?}");
         assert_eq!(render_template(input, &context).unwrap(), expected);
     }
 }
@@ -479,7 +479,7 @@ fn render_if_elif_else() {
     ];
 
     for (input, expected) in inputs {
-        println!("{:?} -> {:?}", input, expected);
+        println!("{input:?} -> {expected:?}");
         assert_eq!(render_template(input, &context).unwrap(), expected);
     }
 }
@@ -570,7 +570,7 @@ fn render_for() {
     ];
 
     for (input, expected) in inputs {
-        println!("{:?} -> {:?}", input, expected);
+        println!("{input:?} -> {expected:?}");
         assert_eq!(render_template(input, &context).unwrap(), expected);
     }
 }
@@ -647,7 +647,7 @@ fn default_filter_works() {
     ];
 
     for (input, expected) in inputs {
-        println!("{:?} -> {:?}", input, expected);
+        println!("{input:?} -> {expected:?}");
         assert_eq!(render_template(input, &context).unwrap(), expected);
     }
 }
@@ -666,7 +666,7 @@ fn filter_filter_works() {
         vec![(r#"{{ authors | filter(attribute="id", value=1) | first | get(key="id") }}"#, "1")];
 
     for (input, expected) in inputs {
-        println!("{:?} -> {:?}", input, expected);
+        println!("{input:?} -> {expected:?}");
         assert_eq!(render_template(input, &context).unwrap(), expected);
     }
 }
@@ -685,7 +685,7 @@ fn filter_on_array_literal_works() {
     ];
 
     for (input, expected) in inputs {
-        println!("{:?} -> {:?}", input, expected);
+        println!("{input:?} -> {expected:?}");
         assert_eq!(render_template(input, &context).unwrap(), expected);
     }
 }
@@ -714,7 +714,7 @@ fn can_do_string_concat() {
     ];
 
     for (input, expected) in inputs {
-        println!("{:?} -> {:?}", input, expected);
+        println!("{input:?} -> {expected:?}");
         assert_eq!(render_template(input, &context).unwrap(), expected);
     }
 }

--- a/src/renderer/tests/basic.rs
+++ b/src/renderer/tests/basic.rs
@@ -18,7 +18,7 @@ fn render_template(content: &str, context: &Context) -> Result<String> {
     let mut tera = Tera::default();
     tera.add_raw_template("hello.html", content).unwrap();
     tera.register_function("get_number", |_: &HashMap<String, Value>| Ok(Value::Number(10.into())));
-    tera.register_function("get_true", |_: &HashMap<String, Value>| Ok(Value::Bool(true.into())));
+    tera.register_function("get_true", |_: &HashMap<String, Value>| Ok(Value::Bool(true)));
     tera.register_function("get_string", |_: &HashMap<String, Value>| {
         Ok(Value::String("Hello".to_string()))
     });

--- a/src/renderer/tests/errors.rs
+++ b/src/renderer/tests/errors.rs
@@ -41,7 +41,7 @@ fn error_loading_macro_from_unloaded_namespace() {
     .unwrap();
 
     let result = tera.render("tpl", &Context::new());
-    println!("{:#?}", result);
+    println!("{result:#?}");
     assert_eq!(
         result.unwrap_err().source().unwrap().to_string(),
         "Macro namespace `macro` was not found in template `tpl`. Have you maybe forgotten to import it, or misspelled it?"
@@ -270,7 +270,7 @@ fn error_gives_source_on_tests() {
     let mut tera = Tera::default();
     tera.add_raw_templates(vec![("tpl", "{% if a is undefined(1) %}-{% endif %}")]).unwrap();
     let result = tera.render("tpl", &Context::new());
-    println!("{:?}", result);
+    println!("{result:?}");
     let err = result.unwrap_err();
 
     let source = err.source().unwrap();

--- a/src/renderer/tests/square_brackets.rs
+++ b/src/renderer/tests/square_brackets.rs
@@ -45,7 +45,7 @@ fn var_access_by_square_brackets() {
     ];
 
     for (input, expected) in inputs {
-        println!("{:?} -> {:?}", input, expected);
+        println!("{input:?} -> {expected:?}");
         assert_eq!(Tera::one_off(input, &context, true).unwrap(), expected);
     }
 }

--- a/src/renderer/tests/whitespace.rs
+++ b/src/renderer/tests/whitespace.rs
@@ -31,7 +31,7 @@ fn can_remove_whitespace_basic() {
     for (input, expected) in inputs {
         let mut tera = Tera::default();
         tera.add_raw_template("tpl", input).unwrap();
-        println!("{} -> {:?}", input, expected);
+        println!("{input} -> {expected:?}");
         assert_eq!(tera.render("tpl", &context).unwrap(), expected);
     }
 }

--- a/src/template.rs
+++ b/src/template.rs
@@ -137,7 +137,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(tpl.parent.unwrap(), "base.html".to_string());
-        assert_eq!(tpl.blocks.contains_key("hey"), true);
+        assert!(tpl.blocks.contains_key("hey"));
     }
 
     #[test]
@@ -149,14 +149,14 @@ mod tests {
         ).unwrap();
 
         assert_eq!(tpl.parent.unwrap(), "base.html".to_string());
-        assert_eq!(tpl.blocks.contains_key("hey"), true);
-        assert_eq!(tpl.blocks.contains_key("extrahey"), true);
+        assert!(tpl.blocks.contains_key("hey"));
+        assert!(tpl.blocks.contains_key("extrahey"));
     }
 
     #[test]
     fn can_find_macros() {
         let tpl = Template::new("hello", None, "{% macro hey() %}{% endmacro hey %}").unwrap();
-        assert_eq!(tpl.macros.contains_key("hey"), true);
+        assert!(tpl.macros.contains_key("hey"));
     }
 
     #[test]

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -48,8 +48,7 @@ impl Tera {
     fn create(dir: &str, parse_only: bool) -> Result<Tera> {
         if dir.find('*').is_none() {
             return Err(Error::msg(format!(
-                "Tera expects a glob as input, no * were found in `{}`",
-                dir
+                "Tera expects a glob as input, no * were found in `{dir}`"
             )));
         }
 
@@ -158,10 +157,10 @@ impl Tera {
                 if let Err(e) = self.add_file(Some(&filepath), path) {
                     use std::error::Error;
 
-                    errors += &format!("\n* {}", e);
+                    errors += &format!("\n* {e}");
                     let mut cause = e.source();
                     while let Some(e) = cause {
-                        errors += &format!("\n{}", e);
+                        errors += &format!("\n{e}");
                         cause = e.source();
                     }
                 }
@@ -183,14 +182,14 @@ impl Tera {
         let tpl_name = name.unwrap_or_else(|| path.to_str().unwrap());
 
         let mut f = File::open(path)
-            .map_err(|e| Error::chain(format!("Couldn't open template '{:?}'", path), e))?;
+            .map_err(|e| Error::chain(format!("Couldn't open template '{path:?}'"), e))?;
 
         let mut input = String::new();
         f.read_to_string(&mut input)
-            .map_err(|e| Error::chain(format!("Failed to read template '{:?}'", path), e))?;
+            .map_err(|e| Error::chain(format!("Failed to read template '{path:?}'"), e))?;
 
         let tpl = Template::new(tpl_name, Some(path.to_str().unwrap().to_string()), &input)
-            .map_err(|e| Error::chain(format!("Failed to parse {:?}", path), e))?;
+            .map_err(|e| Error::chain(format!("Failed to parse {path:?}"), e))?;
 
         self.templates.insert(tpl_name.to_string(), tpl);
         Ok(())
@@ -423,7 +422,7 @@ impl Tera {
     /// ```
     pub fn add_raw_template(&mut self, name: &str, content: &str) -> Result<()> {
         let tpl = Template::new(name, None, content)
-            .map_err(|e| Error::chain(format!("Failed to parse '{}'", name), e))?;
+            .map_err(|e| Error::chain(format!("Failed to parse '{name}'"), e))?;
         self.templates.insert(name.to_string(), tpl);
         self.build_inheritance_chains()?;
         self.check_macro_files()?;
@@ -450,7 +449,7 @@ impl Tera {
         for (name, content) in templates {
             let name = name.as_ref();
             let tpl = Template::new(name, None, content.as_ref())
-                .map_err(|e| Error::chain(format!("Failed to parse '{}'", name), e))?;
+                .map_err(|e| Error::chain(format!("Failed to parse '{name}'"), e))?;
             self.templates.insert(name.to_string(), tpl);
         }
         self.build_inheritance_chains()?;
@@ -776,19 +775,19 @@ impl fmt::Debug for Tera {
         writeln!(f, "\n\ttemplates: [")?;
 
         for template in self.templates.keys() {
-            writeln!(f, "\t\t{},", template)?;
+            writeln!(f, "\t\t{template},")?;
         }
         write!(f, "\t]")?;
         writeln!(f, "\n\tfilters: [")?;
 
         for filter in self.filters.keys() {
-            writeln!(f, "\t\t{},", filter)?;
+            writeln!(f, "\t\t{filter},")?;
         }
         write!(f, "\t]")?;
         writeln!(f, "\n\ttesters: [")?;
 
         for tester in self.testers.keys() {
-            writeln!(f, "\t\t{},", tester)?;
+            writeln!(f, "\t\t{tester},")?;
         }
         writeln!(f, "\t]")?;
 
@@ -1104,7 +1103,7 @@ mod tests {
         for tpl in tera.templates.values_mut() {
             tpl.name = format!("a-theme/templates/{}", tpl.name);
             if let Some(ref parent) = tpl.parent.clone() {
-                tpl.parent = Some(format!("a-theme/templates/{}", parent));
+                tpl.parent = Some(format!("a-theme/templates/{parent}"));
             }
         }
         // Will panic here as we changed the parent and it won't be able
@@ -1172,9 +1171,9 @@ mod tests {
         ];
 
         for (sample, expected_output) in samples {
-            println!("{}, {:?}", sample, expected_output);
+            println!("{sample}, {expected_output:?}");
             let res = Tera::one_off(
-                &format!("{{% if {} %}}true{{% endif %}}", sample),
+                &format!("{{% if {sample} %}}true{{% endif %}}"),
                 &Context::new(),
                 true,
             );

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -152,7 +152,7 @@ impl Tera {
                     .unwrap()
                     .to_string_lossy()
                     // unify on forward slash
-                    .replace("\\", "/");
+                    .replace('\\', "/");
 
                 if let Err(e) = self.add_file(Some(&filepath), path) {
                     use std::error::Error;

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -148,7 +148,7 @@ impl Tera {
                 }
 
                 let filepath = path
-                    .strip_prefix(&parent_dir)
+                    .strip_prefix(parent_dir)
                     .unwrap()
                     .to_string_lossy()
                     // unify on forward slash
@@ -222,7 +222,7 @@ impl Tera {
                         parents.push(parent.name.clone());
                         build_chain(templates, start, parent, parents)
                     }
-                    None => Err(Error::missing_parent(&template.name, &p)),
+                    None => Err(Error::missing_parent(&template.name, p)),
                 },
                 None => Ok(parents),
             }
@@ -353,7 +353,7 @@ impl Tera {
     /// ```
     pub fn render_str(&mut self, input: &str, context: &Context) -> Result<String> {
         self.add_raw_template(ONE_OFF_TEMPLATE_NAME, input)?;
-        let result = self.render(ONE_OFF_TEMPLATE_NAME, &context);
+        let result = self.render(ONE_OFF_TEMPLATE_NAME, context);
         self.templates.remove(ONE_OFF_TEMPLATE_NAME);
         result
     }

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -282,7 +282,7 @@ impl Tera {
     /// As with `self::build_inheritance_chains`, you don't usually need to call that yourself.
     pub fn check_macro_files(&self) -> Result<()> {
         for template in self.templates.values() {
-            for &(ref tpl_name, _) in &template.imported_macro_files {
+            for (tpl_name, _) in &template.imported_macro_files {
                 if !self.templates.contains_key(tpl_name) {
                     return Err(Error::msg(format!(
                         "Template `{}` loads macros from `{}` which isn't present in Tera",

--- a/tests/render_fails.rs
+++ b/tests/render_fails.rs
@@ -25,7 +25,7 @@ fn render_tpl(tpl_name: &str) -> Result<String> {
 fn test_error_render_field_unknown() {
     let result = render_tpl("field_unknown.html");
 
-    assert_eq!(result.is_err(), true);
+    assert!(result.is_err());
     assert_eq!(
         result.unwrap_err().source().unwrap().to_string(),
         "Variable `hey` not found in context while rendering \'field_unknown.html\'"
@@ -36,7 +36,7 @@ fn test_error_render_field_unknown() {
 fn test_error_render_field_unknown_in_forloop() {
     let result = render_tpl("field_unknown_forloop.html");
 
-    assert_eq!(result.is_err(), true);
+    assert!(result.is_err());
     let err = result.unwrap_err();
     assert_eq!(
         err.source().unwrap().to_string(),
@@ -48,7 +48,7 @@ fn test_error_render_field_unknown_in_forloop() {
 fn test_error_render_non_math() {
     let result = render_tpl("non_math_operation.html");
 
-    assert_eq!(result.is_err(), true);
+    assert!(result.is_err());
     assert_eq!(
         result.unwrap_err().source().unwrap().to_string(),
         "Variable `username` was used in a math operation but is not a number"
@@ -58,7 +58,7 @@ fn test_error_render_non_math() {
 #[test]
 fn test_error_render_filter_section_invalid() {
     let result = render_tpl("filter_section_invalid.html");
-    assert_eq!(result.is_err(), true);
+    assert!(result.is_err());
     let err = result.unwrap_err();
     let source = err.source().unwrap();
 
@@ -74,7 +74,7 @@ fn test_error_render_filter_section_invalid() {
 fn test_error_render_iterate_non_array() {
     let result = render_tpl("iterate_on_non_array.html");
 
-    assert_eq!(result.is_err(), true);
+    assert!(result.is_err());
     assert_eq!(
         result.unwrap_err().source().unwrap().to_string(),
         "Tried to iterate on a container (`friend_reviewed`) that has a unsupported type"
@@ -85,7 +85,7 @@ fn test_error_render_iterate_non_array() {
 fn test_error_wrong_args_macros() {
     let result = render_tpl("macro_wrong_args.html");
 
-    assert_eq!(result.is_err(), true);
+    assert!(result.is_err());
     assert!(result
         .unwrap_err()
         .source()
@@ -98,7 +98,7 @@ fn test_error_wrong_args_macros() {
 fn test_error_macros_self_inexisting() {
     let result = render_tpl("macro_self_inexisting.html");
 
-    assert_eq!(result.is_err(), true);
+    assert!(result.is_err());
     assert_eq!(
         result.unwrap_err().source().unwrap().to_string(),
         "Macro `self::inexisting` not found in template `macros.html`"
@@ -109,7 +109,7 @@ fn test_error_macros_self_inexisting() {
 fn test_error_in_child_template_location() {
     let result = render_tpl("error-location/error_in_child.html");
 
-    assert_eq!(result.is_err(), true);
+    assert!(result.is_err());
     let errs = result.unwrap_err();
     assert_eq!(errs.to_string(), "Failed to render 'error-location/error_in_child.html'");
 }
@@ -118,7 +118,7 @@ fn test_error_in_child_template_location() {
 fn test_error_in_grandchild_template_location() {
     let result = render_tpl("error-location/error_in_grand_child.html");
 
-    assert_eq!(result.is_err(), true);
+    assert!(result.is_err());
     let errs = result.unwrap_err();
     assert_eq!(errs.to_string(), "Failed to render 'error-location/error_in_grand_child.html'");
 }
@@ -127,7 +127,7 @@ fn test_error_in_grandchild_template_location() {
 fn test_error_in_parent_template_location() {
     let result = render_tpl("error-location/error_in_parent.html");
 
-    assert_eq!(result.is_err(), true);
+    assert!(result.is_err());
     let errs = result.unwrap_err();
     assert_eq!(
         errs.to_string(),
@@ -139,7 +139,7 @@ fn test_error_in_parent_template_location() {
 fn test_error_in_macro_location() {
     let result = render_tpl("error-location/error_in_macro.html");
 
-    assert_eq!(result.is_err(), true);
+    assert!(result.is_err());
     let errs = result.unwrap_err();
     assert_eq!(
         errs.to_string(),


### PR DESCRIPTION
I fixed plenty of clippy warnings and errors.
I updated the dependencies.
Also I replaced some deprecated functions of the parser, humansize, and chrono.
The only real change is the sorting function, which should be faster now.