### PR TITLE
replace try_get_value macro with try_get_value generic

### DIFF
--- a/examples/basic/main.rs
+++ b/examples/basic/main.rs
@@ -1,6 +1,4 @@
 #[macro_use]
-extern crate tera;
-#[macro_use]
 extern crate lazy_static;
 extern crate serde_json;
 
@@ -8,6 +6,7 @@ use std::collections::HashMap;
 
 use serde_json::value::{to_value, Value};
 use std::error::Error;
+use tera::try_get_value_as_type;
 use tera::{Context, Result, Tera};
 
 lazy_static! {
@@ -26,7 +25,7 @@ lazy_static! {
 }
 
 pub fn do_nothing_filter(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
-    let s = try_get_value!("do_nothing_filter", "value", String, value);
+    let s: String = try_get_value_as_type("do_nothing_filter", "value", value)?;
     Ok(to_value(&s).unwrap())
 }
 

--- a/src/builtins/filters/array.rs
+++ b/src/builtins/filters/array.rs
@@ -1,23 +1,23 @@
-/// Filters operating on array
-use std::collections::HashMap;
-
 use crate::context::{get_json_pointer, ValueRender};
 use crate::errors::{Error, Result};
 use crate::filter_utils::{get_sort_strategy_for_type, get_unique_strategy_for_type};
 use crate::utils::render_to_string;
+use crate::utils::try_get_value;
 use serde_json::value::{to_value, Map, Value};
+/// Filters operating on array
+use std::collections::HashMap;
 
 /// Returns the nth value of an array
 /// If the array is empty, returns empty string
 pub fn nth(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
-    let arr = try_get_value!("nth", "value", Vec<Value>, value);
+    let arr: Vec<Value> = try_get_value("nth", "value", value)?;
 
     if arr.is_empty() {
         return Ok(to_value("").unwrap());
     }
 
-    let index = match args.get("n") {
-        Some(val) => try_get_value!("nth", "n", usize, val),
+    let index: usize = match args.get("n") {
+        Some(val) => try_get_value("nth", "n", val)?,
         None => return Err(Error::msg("The `nth` filter has to have an `n` argument")),
     };
 
@@ -27,7 +27,7 @@ pub fn nth(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
 /// Returns the first value of an array
 /// If the array is empty, returns empty string
 pub fn first(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
-    let mut arr = try_get_value!("first", "value", Vec<Value>, value);
+    let mut arr: Vec<Value> = try_get_value("first", "value", value)?;
 
     if arr.is_empty() {
         Ok(to_value("").unwrap())
@@ -39,7 +39,7 @@ pub fn first(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
 /// Returns the last value of an array
 /// If the array is empty, returns empty string
 pub fn last(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
-    let mut arr = try_get_value!("last", "value", Vec<Value>, value);
+    let mut arr: Vec<Value> = try_get_value("last", "value", value)?;
 
     Ok(arr.pop().unwrap_or_else(|| to_value("").unwrap()))
 }
@@ -48,9 +48,9 @@ pub fn last(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
 /// If no separator is given, it will use `""` (empty string) as separator
 /// If the array is empty, returns empty string
 pub fn join(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
-    let arr = try_get_value!("join", "value", Vec<Value>, value);
-    let sep = match args.get("sep") {
-        Some(val) => try_get_value!("truncate", "sep", String, val),
+    let arr: Vec<Value> = try_get_value("join", "value", value)?;
+    let sep: String = match args.get("sep") {
+        Some(val) => try_get_value("truncate", "sep", val)?,
         None => String::new(),
     };
 
@@ -65,13 +65,13 @@ pub fn join(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
 /// Sorts the array in ascending order.
 /// Use the 'attribute' argument to define a field to sort by.
 pub fn sort(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
-    let arr = try_get_value!("sort", "value", Vec<Value>, value);
+    let arr: Vec<Value> = try_get_value("sort", "value", value)?;
     if arr.is_empty() {
         return Ok(arr.into());
     }
 
     let attribute = match args.get("attribute") {
-        Some(val) => try_get_value!("sort", "attribute", String, val),
+        Some(val) => try_get_value("sort", "attribute", val)?,
         None => String::new(),
     };
     let ptr = match attribute.as_str() {
@@ -99,18 +99,18 @@ pub fn sort(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
 /// Use the 'attribute' argument to define a field to filter on.
 /// For strings, use the 'case_sensitive' argument (defaults to false) to control the comparison.
 pub fn unique(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
-    let arr = try_get_value!("unique", "value", Vec<Value>, value);
+    let arr: Vec<Value> = try_get_value("unique", "value", value)?;
     if arr.is_empty() {
         return Ok(arr.into());
     }
 
     let case_sensitive = match args.get("case_sensitive") {
-        Some(val) => try_get_value!("unique", "case_sensitive", bool, val),
+        Some(val) => try_get_value("unique", "case_sensitive", val)?,
         None => false,
     };
 
     let attribute = match args.get("attribute") {
-        Some(val) => try_get_value!("unique", "attribute", String, val),
+        Some(val) => try_get_value("unique", "attribute", val)?,
         None => String::new(),
     };
     let ptr = match attribute.as_str() {
@@ -150,13 +150,13 @@ pub fn unique(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
 /// Returns a hashmap of key => values, items without the `attribute` or where `attribute` is `null` are discarded.
 /// The returned keys are stringified
 pub fn group_by(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
-    let arr = try_get_value!("group_by", "value", Vec<Value>, value);
+    let arr: Vec<Value> = try_get_value("group_by", "value", value)?;
     if arr.is_empty() {
         return Ok(Map::new().into());
     }
 
-    let key = match args.get("attribute") {
-        Some(val) => try_get_value!("group_by", "attribute", String, val),
+    let key: String = match args.get("attribute") {
+        Some(val) => try_get_value("group_by", "attribute", val)?,
         None => {
             return Err(Error::msg("The `group_by` filter has to have an `attribute` argument"))
         }
@@ -192,13 +192,13 @@ pub fn group_by(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
 /// Values without the `attribute` or with a null `attribute` are discarded
 /// If the `value` is not passed, discard all elements where the attribute is null.
 pub fn filter(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
-    let mut arr = try_get_value!("filter", "value", Vec<Value>, value);
+    let mut arr: Vec<Value> = try_get_value("filter", "value", value)?;
     if arr.is_empty() {
         return Ok(arr.into());
     }
 
-    let key = match args.get("attribute") {
-        Some(val) => try_get_value!("filter", "attribute", String, val),
+    let key: String = match args.get("attribute") {
+        Some(val) => try_get_value("filter", "attribute", val)?,
         None => return Err(Error::msg("The `filter` filter has to have an `attribute` argument")),
     };
     let value = args.get("value").unwrap_or(&Value::Null);
@@ -222,13 +222,13 @@ pub fn filter(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
 /// Map retrieves an attribute from a list of objects.
 /// The 'attribute' argument specifies what to retrieve.
 pub fn map(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
-    let arr = try_get_value!("map", "value", Vec<Value>, value);
+    let arr: Vec<Value> = try_get_value("map", "value", value)?;
     if arr.is_empty() {
         return Ok(arr.into());
     }
 
-    let attribute = match args.get("attribute") {
-        Some(val) => try_get_value!("map", "attribute", String, val),
+    let attribute: String = match args.get("attribute") {
+        Some(val) => try_get_value("map", "attribute", val)?,
         None => return Err(Error::msg("The `map` filter has to have an `attribute` argument")),
     };
 
@@ -258,18 +258,18 @@ fn get_index(i: f64, array: &[Value]) -> usize {
 /// and `end` argument to define where to stop (exclusive, default to the length of the array)
 /// `start` and `end` are 0-indexed
 pub fn slice(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
-    let arr = try_get_value!("slice", "value", Vec<Value>, value);
+    let arr: Vec<Value> = try_get_value("slice", "value", value)?;
     if arr.is_empty() {
         return Ok(arr.into());
     }
 
     let start = match args.get("start") {
-        Some(val) => get_index(try_get_value!("slice", "start", f64, val), &arr),
+        Some(val) => get_index(try_get_value("slice", "start", val)?, &arr),
         None => 0,
     };
 
     let mut end = match args.get("end") {
-        Some(val) => get_index(try_get_value!("slice", "end", f64, val), &arr),
+        Some(val) => get_index(try_get_value("slice", "end", val)?, &arr),
         None => arr.len(),
     };
 
@@ -288,7 +288,7 @@ pub fn slice(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
 /// Concat the array with another one if the `with` parameter is an array or
 /// just append it otherwise
 pub fn concat(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
-    let mut arr = try_get_value!("concat", "value", Vec<Value>, value);
+    let mut arr: Vec<Value> = try_get_value("concat", "value", value)?;
 
     let value = match args.get("with") {
         Some(val) => val,

--- a/src/builtins/filters/common.rs
+++ b/src/builtins/filters/common.rs
@@ -6,6 +6,7 @@ use std::iter::FromIterator;
 
 use crate::errors::{Error, Result};
 use crate::utils::render_to_string;
+use crate::utils::try_get_value;
 #[cfg(feature = "builtins")]
 use chrono::{
     format::{Item, StrftimeItems},
@@ -69,8 +70,8 @@ pub fn json_encode(value: &Value, args: &HashMap<String, Value>) -> Result<Value
 /// on [chrono docs](https://lifthrasiir.github.io/rust-chrono/chrono/format/strftime/index.html)
 #[cfg(feature = "builtins")]
 pub fn date(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
-    let format = match args.get("format") {
-        Some(val) => try_get_value!("date", "format", String, val),
+    let format: String = match args.get("format") {
+        Some(val) => try_get_value("date", "format", val)?,
         None => "%Y-%m-%d".to_string(),
     };
 
@@ -86,7 +87,7 @@ pub fn date(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
 
     let timezone = match args.get("timezone") {
         Some(val) => {
-            let timezone = try_get_value!("date", "timezone", String, val);
+            let timezone: String = try_get_value("date", "timezone", val)?;
             match timezone.parse::<Tz>() {
                 Ok(timezone) => Some(timezone),
                 Err(_) => {
@@ -101,7 +102,7 @@ pub fn date(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
     let formatted = {
         let locale = match args.get("locale") {
             Some(val) => {
-                let locale = try_get_value!("date", "locale", String, val);
+                let locale: String = try_get_value("date", "locale", val)?;
                 chrono::Locale::try_from(locale.as_str()).or_else(|_| {
                     Err(Error::msg(format!("Error parsing `{}` as a locale", locale)))
                 })?

--- a/src/builtins/filters/number.rs
+++ b/src/builtins/filters/number.rs
@@ -1,25 +1,25 @@
 /// Filters operating on numbers
 use std::collections::HashMap;
 
+use crate::errors::{Error, Result};
+use crate::utils::try_get_value;
 #[cfg(feature = "builtins")]
 use humansize::{file_size_opts, FileSize};
 use serde_json::value::{to_value, Value};
-
-use crate::errors::{Error, Result};
 
 /// Returns a plural suffix if the value is not equal to ±1, or a singular
 /// suffix otherwise. The plural suffix defaults to `s` and the singular suffix
 /// defaults to the empty string (i.e nothing).
 pub fn pluralize(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
-    let num = try_get_value!("pluralize", "value", f64, value);
+    let num: f64 = try_get_value("pluralize", "value", value)?;
 
-    let plural = match args.get("plural") {
-        Some(val) => try_get_value!("pluralize", "plural", String, val),
+    let plural: String = match args.get("plural") {
+        Some(val) => try_get_value("pluralize", "plural", val)?,
         None => "s".to_string(),
     };
 
-    let singular = match args.get("singular") {
-        Some(val) => try_get_value!("pluralize", "singular", String, val),
+    let singular: String = match args.get("singular") {
+        Some(val) => try_get_value("pluralize", "singular", val)?,
         None => "".to_string(),
     };
 
@@ -36,13 +36,13 @@ pub fn pluralize(value: &Value, args: &HashMap<String, Value>) -> Result<Value> 
 /// `ceil` and `floor` are also available as method.
 /// `precision` defaults to `0`, meaning it will round to an integer
 pub fn round(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
-    let num = try_get_value!("round", "value", f64, value);
+    let num: f64 = try_get_value("round", "value", value)?;
     let method = match args.get("method") {
-        Some(val) => try_get_value!("round", "method", String, val),
+        Some(val) => try_get_value("round", "method", val)?,
         None => "common".to_string(),
     };
-    let precision = match args.get("precision") {
-        Some(val) => try_get_value!("round", "precision", i32, val),
+    let precision: i32 = match args.get("precision") {
+        Some(val) => try_get_value("round", "precision", val)?,
         None => 0,
     };
     let multiplier = if precision == 0 { 1.0 } else { 10.0_f64.powi(precision) };
@@ -62,7 +62,7 @@ pub fn round(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
 /// Returns a human-readable file size (i.e. '110 MB') from an integer
 #[cfg(feature = "builtins")]
 pub fn filesizeformat(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
-    let num = try_get_value!("filesizeformat", "value", usize, value);
+    let num: usize = try_get_value("filesizeformat", "value", value)?;
     num.file_size(file_size_opts::CONVENTIONAL)
         .map_err(|_| {
             Error::msg(format!("Filter `filesizeformat` was called on a negative number: {}", num))

--- a/src/builtins/filters/object.rs
+++ b/src/builtins/filters/object.rs
@@ -4,12 +4,13 @@ use std::collections::HashMap;
 use serde_json::value::Value;
 
 use crate::errors::{Error, Result};
+use crate::utils::try_get_value;
 
 /// Returns a value by a `key` argument from a given object
 pub fn get(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
     let default = args.get("default");
-    let key = match args.get("key") {
-        Some(val) => try_get_value!("get", "key", String, val),
+    let key: String = match args.get("key") {
+        Some(val) => try_get_value("get", "key", val)?,
         None => return Err(Error::msg("The `get` filter has to have an `key` argument")),
     };
 

--- a/src/builtins/filters/string.rs
+++ b/src/builtins/filters/string.rs
@@ -11,6 +11,7 @@ use percent_encoding::{percent_encode, AsciiSet, NON_ALPHANUMERIC};
 
 use crate::errors::{Error, Result};
 use crate::utils;
+use crate::utils::try_get_value;
 
 /// https://url.spec.whatwg.org/#fragment-percent-encode-set
 #[cfg(feature = "urlencode")]
@@ -67,46 +68,46 @@ lazy_static! {
 
 /// Convert a value to uppercase.
 pub fn upper(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
-    let s = try_get_value!("upper", "value", String, value);
+    let s: String = try_get_value("upper", "value", value)?;
 
     Ok(to_value(&s.to_uppercase()).unwrap())
 }
 
 /// Convert a value to lowercase.
 pub fn lower(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
-    let s = try_get_value!("lower", "value", String, value);
+    let s: String = try_get_value("lower", "value", value)?;
 
     Ok(to_value(&s.to_lowercase()).unwrap())
 }
 
 /// Strip leading and trailing whitespace.
 pub fn trim(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
-    let s = try_get_value!("trim", "value", String, value);
+    let s: String = try_get_value("trim", "value", value)?;
 
     Ok(to_value(&s.trim()).unwrap())
 }
 
 /// Strip leading whitespace.
 pub fn trim_start(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
-    let s = try_get_value!("trim_start", "value", String, value);
+    let s: String = try_get_value("trim_start", "value", value)?;
 
     Ok(to_value(&s.trim_start()).unwrap())
 }
 
 /// Strip trailing whitespace.
 pub fn trim_end(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
-    let s = try_get_value!("trim_end", "value", String, value);
+    let s: String = try_get_value("trim_end", "value", value)?;
 
     Ok(to_value(&s.trim_end()).unwrap())
 }
 
 /// Strip leading characters that match the given pattern.
 pub fn trim_start_matches(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
-    let s = try_get_value!("trim_start_matches", "value", String, value);
+    let s: String = try_get_value("trim_start_matches", "value", value)?;
 
     let pat = match args.get("pat") {
         Some(pat) => {
-            let p = try_get_value!("trim_start_matches", "pat", String, pat);
+            let p: String = try_get_value("trim_start_matches", "pat", pat)?;
             // When reading from a file, it will escape `\n` to `\\n` for example so we need
             // to replace double escape. In practice it might cause issues if someone wants to split
             // by `\\n` for real but that seems pretty unlikely
@@ -120,11 +121,11 @@ pub fn trim_start_matches(value: &Value, args: &HashMap<String, Value>) -> Resul
 
 /// Strip trailing characters that match the given pattern.
 pub fn trim_end_matches(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
-    let s = try_get_value!("trim_end_matches", "value", String, value);
+    let s: String = try_get_value("trim_end_matches", "value", value)?;
 
     let pat = match args.get("pat") {
         Some(pat) => {
-            let p = try_get_value!("trim_end_matches", "pat", String, pat);
+            let p: String = try_get_value("trim_end_matches", "pat", pat)?;
             // When reading from a file, it will escape `\n` to `\\n` for example so we need
             // to replace double escape. In practice it might cause issues if someone wants to split
             // by `\\n` for real but that seems pretty unlikely
@@ -155,13 +156,13 @@ pub fn trim_end_matches(value: &Value, args: &HashMap<String, Value>) -> Result<
 /// string is *added* after the truncation occurs.
 ///
 pub fn truncate(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
-    let s = try_get_value!("truncate", "value", String, value);
-    let length = match args.get("length") {
-        Some(l) => try_get_value!("truncate", "length", usize, l),
+    let s: String = try_get_value("truncate", "value", value)?;
+    let length: usize = match args.get("length") {
+        Some(l) => try_get_value("truncate", "length", l)?,
         None => 255,
     };
-    let end = match args.get("end") {
-        Some(l) => try_get_value!("truncate", "end", String, l),
+    let end: String = match args.get("end") {
+        Some(l) => try_get_value("truncate", "end", l)?,
         None => "…".to_string(),
     };
 
@@ -178,22 +179,22 @@ pub fn truncate(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
 
 /// Gets the number of words in a string.
 pub fn wordcount(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
-    let s = try_get_value!("wordcount", "value", String, value);
+    let s: String = try_get_value("wordcount", "value", value)?;
 
     Ok(to_value(&s.split_whitespace().count()).unwrap())
 }
 
 /// Replaces given `from` substring with `to` string.
 pub fn replace(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
-    let s = try_get_value!("replace", "value", String, value);
+    let s: String = try_get_value("replace", "value", value)?;
 
-    let from = match args.get("from") {
-        Some(val) => try_get_value!("replace", "from", String, val),
+    let from: String = match args.get("from") {
+        Some(val) => try_get_value("replace", "from", val)?,
         None => return Err(Error::msg("Filter `replace` expected an arg called `from`")),
     };
 
-    let to = match args.get("to") {
-        Some(val) => try_get_value!("replace", "to", String, val),
+    let to: String = match args.get("to") {
+        Some(val) => try_get_value("replace", "to", val)?,
         None => return Err(Error::msg("Filter `replace` expected an arg called `to`")),
     };
 
@@ -202,7 +203,7 @@ pub fn replace(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
 
 /// First letter of the string is uppercase rest is lowercase
 pub fn capitalize(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
-    let s = try_get_value!("capitalize", "value", String, value);
+    let s: String = try_get_value("capitalize", "value", value)?;
     let mut chars = s.chars();
     match chars.next() {
         None => Ok(to_value("").unwrap()),
@@ -216,7 +217,7 @@ pub fn capitalize(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
 /// Percent-encodes reserved URI characters
 #[cfg(feature = "urlencode")]
 pub fn urlencode(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
-    let s = try_get_value!("urlencode", "value", String, value);
+    let s: String = try_get_value("urlencode", "value", value)?;
     let encoded = percent_encode(s.as_bytes(), &PYTHON_ENCODE_SET).to_string();
     Ok(Value::String(encoded))
 }
@@ -224,27 +225,27 @@ pub fn urlencode(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
 /// Percent-encodes all non-alphanumeric characters
 #[cfg(feature = "urlencode")]
 pub fn urlencode_strict(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
-    let s = try_get_value!("urlencode_strict", "value", String, value);
+    let s: String = try_get_value("urlencode_strict", "value", value)?;
     let encoded = percent_encode(s.as_bytes(), &NON_ALPHANUMERIC).to_string();
     Ok(Value::String(encoded))
 }
 
 /// Escapes quote characters
 pub fn addslashes(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
-    let s = try_get_value!("addslashes", "value", String, value);
+    let s: String = try_get_value("addslashes", "value", value)?;
     Ok(to_value(&s.replace("\\", "\\\\").replace("\"", "\\\"").replace("\'", "\\\'")).unwrap())
 }
 
 /// Transform a string into a slug
 #[cfg(feature = "builtins")]
 pub fn slugify(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
-    let s = try_get_value!("slugify", "value", String, value);
+    let s: String = try_get_value("slugify", "value", value)?;
     Ok(to_value(&slug::slugify(s)).unwrap())
 }
 
 /// Capitalizes each word in the string
 pub fn title(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
-    let s = try_get_value!("title", "value", String, value);
+    let s: String = try_get_value("title", "value", value)?;
 
     Ok(to_value(&WORDS_RE.replace_all(&s, |caps: &Captures| {
         let first = caps["first"].to_uppercase();
@@ -258,32 +259,32 @@ pub fn title(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
 ///
 /// Example: The input "Hello\nWorld" turns into "Hello<br>World".
 pub fn linebreaksbr(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
-    let s = try_get_value!("title", "value", String, value);
+    let s: String = try_get_value("title", "value", value)?;
     Ok(to_value(&s.replace("\r\n", "<br>").replace("\n", "<br>")).unwrap())
 }
 
 /// Removes html tags from string
 pub fn striptags(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
-    let s = try_get_value!("striptags", "value", String, value);
+    let s: String = try_get_value("striptags", "value", value)?;
     Ok(to_value(&STRIPTAGS_RE.replace_all(&s, "")).unwrap())
 }
 
 /// Removes spaces between html tags from string
 pub fn spaceless(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
-    let s = try_get_value!("spaceless", "value", String, value);
+    let s: String = try_get_value("spaceless", "value", value)?;
     Ok(to_value(&SPACELESS_RE.replace_all(&s, "><")).unwrap())
 }
 
 /// Returns the given text with all special HTML characters encoded
 pub fn escape_html(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
-    let s = try_get_value!("escape_html", "value", String, value);
+    let s: String = try_get_value("escape_html", "value", value)?;
     Ok(Value::String(utils::escape_html(&s)))
 }
 
 /// Returns the given text with all special XML characters encoded
 /// Very similar to `escape_html`, just a few characters less are encoded
 pub fn escape_xml(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
-    let s = try_get_value!("escape_html", "value", String, value);
+    let s: String = try_get_value("escape_html", "value", value)?;
 
     let mut output = String::with_capacity(s.len() * 2);
     for c in s.chars() {
@@ -301,11 +302,11 @@ pub fn escape_xml(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
 
 /// Split the given string by the given pattern.
 pub fn split(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
-    let s = try_get_value!("split", "value", String, value);
+    let s: String = try_get_value("split", "value", value)?;
 
     let pat = match args.get("pat") {
         Some(pat) => {
-            let p = try_get_value!("split", "pat", String, pat);
+            let p: String = try_get_value("split", "pat", pat)?;
             // When reading from a file, it will escape `\n` to `\\n` for example so we need
             // to replace double escape. In practice it might cause issues if someone wants to split
             // by `\\n` for real but that seems pretty unlikely
@@ -319,12 +320,12 @@ pub fn split(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
 
 /// Convert the value to a signed integer number
 pub fn int(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
-    let default = match args.get("default") {
-        Some(d) => try_get_value!("int", "default", i64, d),
+    let default: i64 = match args.get("default") {
+        Some(d) => try_get_value("int", "default", d)?,
         None => 0,
     };
-    let base = match args.get("base") {
-        Some(b) => try_get_value!("int", "base", u32, b),
+    let base: u32 = match args.get("base") {
+        Some(b) => try_get_value("int", "base", b)?,
         None => 10,
     };
 
@@ -367,8 +368,8 @@ pub fn int(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
 
 /// Convert the value to a floating point number
 pub fn float(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
-    let default = match args.get("default") {
-        Some(d) => try_get_value!("float", "default", f64, d),
+    let default: f64 = match args.get("default") {
+        Some(d) => try_get_value("float", "default", d)?,
         None => 0.0,
     };
 
@@ -411,7 +412,7 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(
             result.err().unwrap().to_string(),
-            "Filter `upper` was called on an incorrect value: got `50` but expected a String"
+            "Filter `upper` was called on an incorrect value: got `50` but expected a alloc::string::String"
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,8 @@ pub use crate::utils::escape_html;
 /// so apps/tools can encode data in Tera types
 pub use serde_json::value::{from_value, to_value, Map, Number, Value};
 
+pub use crate::utils::try_get_value as try_get_value_as_type;
+
 // Exposes the AST if one needs it but changing the AST is not considered
 // a breaking change so it isn't public
 #[doc(hidden)]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -13,6 +13,10 @@
 /// let val = try_get_value!("pluralize", "suffix", String, val.clone());
 /// ```
 #[macro_export]
+#[deprecated(
+    since = "1.18.0",
+    note = "the try_get_value was replaced with the utils::try_get_value generic function"
+)]
 macro_rules! try_get_value {
     ($filter_name:expr, $var_name:expr, $ty:ty, $val:expr) => {{
         match $crate::from_value::<$ty>($val.clone()) {

--- a/src/renderer/tests/square_brackets.rs
+++ b/src/renderer/tests/square_brackets.rs
@@ -93,7 +93,6 @@ fn var_access_by_loop_index_with_set() {
     assert!(res.is_ok());
 }
 
-
 // https://github.com/Keats/tera/issues/754
 #[test]
 fn can_get_value_if_key_contains_period() {
@@ -103,11 +102,7 @@ fn can_get_value_if_key_contains_period() {
     map.insert("Mt. Robson Provincial Park".to_string(), "hello".to_string());
     context.insert("tag_info", &map);
 
-    let res = Tera::one_off(
-        r#"{{ tag_info[name] }}"#,
-        &context,
-        true,
-    );
+    let res = Tera::one_off(r#"{{ tag_info[name] }}"#, &context, true);
     assert!(res.is_ok());
     let res = res.unwrap();
     assert_eq!(res, "hello");


### PR DESCRIPTION
Since generics are possible since ~1.51 we can replace the try_get_value macro with a generic.
To not change the speed of the implementation try_get_value is inlined.

I left the macro inplace as deprecated, so we don't introduce a breaking change.