### PR TITLE
Faster get_json_pointer

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -226,15 +226,17 @@ pub fn get_json_pointer(key: &str) -> String {
     }
 
     if key.find('"').is_some() {
-        let segments: Vec<&str> = iter::once("")
-            .chain(JSON_POINTER_REGEX.find_iter(key).map(|mat| mat.as_str().trim_matches('"')))
-            .collect();
-        segments.join("/")
+        let mut res = String::with_capacity(key.len() + 1);
+        for mat in JSON_POINTER_REGEX.find_iter(key) {
+            res.push('/');
+            res.push_str(mat.as_str().trim_matches('"'));
+        }
+        res
     } else {
-        let mut out = String::with_capacity(key.len() + 1);
-        out.push('/');
-        out.push_str(&key.replace('.', "/"));
-        out
+        let mut res = String::with_capacity(key.len() + 1);
+        res.push('/');
+        res.push_str(&key.replace('.', "/"));
+        res
     }
 }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -231,7 +231,10 @@ pub fn get_json_pointer(key: &str) -> String {
             .collect();
         segments.join("/")
     } else {
-        ["/", &key.replace(".", "/")].join("")
+        let mut out = String::with_capacity(key.len() + 1);
+        out.push('/');
+        out.push_str(&key.replace('.', "/"));
+        out
     }
 }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -224,20 +224,17 @@ pub fn get_json_pointer(key: &str) -> String {
         // to fix https://github.com/Keats/tera/issues/590
         static ref JSON_POINTER_REGEX: regex::Regex = regex::Regex::new(r#""[^"]*"|[^.]+"#).unwrap();
     }
-
+    let mut res = String::with_capacity(key.len() + 1);
     if key.find('"').is_some() {
-        let mut res = String::with_capacity(key.len() + 1);
         for mat in JSON_POINTER_REGEX.find_iter(key) {
             res.push('/');
             res.push_str(mat.as_str().trim_matches('"'));
         }
-        res
     } else {
-        let mut res = String::with_capacity(key.len() + 1);
         res.push('/');
         res.push_str(&key.replace('.', "/"));
-        res
     }
+    res
 }
 
 #[cfg(test)]


### PR DESCRIPTION
I improved the speed of get_json_pointer by preallocating the String

before:
test bench_get_json_pointer          ... bench:         114 ns/iter (+/- 5)
test bench_get_json_pointer_with_map ... bench:         568 ns/iter (+/- 10)

after:
test bench_get_json_pointer          ... bench:          92 ns/iter (+/- 3)
test bench_get_json_pointer_with_map ... bench:         434 ns/iter (+/- 13)

not a breaking change.