### PR TITLE
Feature ahash and seahash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,9 @@ chrono-tz = {version = "0.6", optional = true}
 # used in get_random function
 rand = {version = "0.8", optional = true}
 
-# used for faster hashmaps with fxhash
-rustc-hash = {version = "1.1.0", optional = true, default-features = false}
+# used for faster hashmaps
+seahash = {version = "4.1.0", optional = true, default-features = false}
+ahash = {version = "0.8.3", optional = true, default-features = false}
 
 [dev-dependencies]
 serde_derive = "1.0"
@@ -50,4 +51,5 @@ builtins = ["urlencode", "slug", "humansize", "chrono", "chrono-tz", "rand"]
 urlencode = ["percent-encoding"]
 preserve_order = ["serde_json/preserve_order"]
 date-locale = ["builtins", "chrono/unstable-locales"]
-fxhash = ["rustc-hash"]
+seahash_hashmap = ["seahash"]
+ahash_hashmap = ["ahash"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,14 +36,18 @@ chrono-tz = {version = "0.6", optional = true}
 # used in get_random function
 rand = {version = "0.8", optional = true}
 
+# used for faster hashmaps with fxhash
+rustc-hash = {version = "1.1.0", optional = true, default-features = false}
+
 [dev-dependencies]
 serde_derive = "1.0"
 pretty_assertions = "1"
 tempfile = "3"
 
 [features]
-default = ["builtins"]
+default = ["builtins", "fxhash"]
 builtins = ["urlencode", "slug", "humansize", "chrono", "chrono-tz", "rand"]
 urlencode = ["percent-encoding"]
 preserve_order = ["serde_json/preserve_order"]
 date-locale = ["builtins", "chrono/unstable-locales"]
+fxhash = ["rustc-hash"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ pretty_assertions = "1"
 tempfile = "3"
 
 [features]
-default = ["builtins", "fxhash"]
+default = ["builtins"]
 builtins = ["urlencode", "slug", "humansize", "chrono", "chrono-tz", "rand"]
 urlencode = ["percent-encoding"]
 preserve_order = ["serde_json/preserve_order"]

--- a/src/builtins/functions.rs
+++ b/src/builtins/functions.rs
@@ -247,7 +247,7 @@ mod tests {
 
         let res = now(&args).unwrap();
         assert!(res.is_string());
-        assert!(res.as_str().unwrap().contains("T"));
+        assert!(res.as_str().unwrap().contains('T'));
     }
 
     #[cfg(feature = "builtins")]
@@ -260,7 +260,7 @@ mod tests {
         assert!(res.is_string());
         let val = res.as_str().unwrap();
         println!("{}", val);
-        assert!(val.contains("T"));
+        assert!(val.contains('T'));
         assert!(val.contains("+00:00"));
     }
 

--- a/src/renderer/macros.rs
+++ b/src/renderer/macros.rs
@@ -1,17 +1,16 @@
 use crate::errors::{Error, Result};
 use crate::parser::ast::MacroDefinition;
 use crate::template::Template;
-use crate::tera::Tera;
-use std::collections::HashMap;
+use crate::tera::{Tera, TeraHashMap};
 
 // Types around Macros get complicated, simplify it a bit by using aliases
 
 /// Maps { macro => macro_definition }
-pub type MacroDefinitionMap = HashMap<String, MacroDefinition>;
+pub type MacroDefinitionMap = TeraHashMap<String, MacroDefinition>;
 /// Maps { namespace => ( macro_template, { macro => macro_definition }) }
-pub type MacroNamespaceMap<'a> = HashMap<&'a str, (&'a str, &'a MacroDefinitionMap)>;
+pub type MacroNamespaceMap<'a> = TeraHashMap<&'a str, (&'a str, &'a MacroDefinitionMap)>;
 /// Maps { template => { namespace => ( macro_template, { macro => macro_definition }) }
-pub type MacroTemplateMap<'a> = HashMap<&'a str, MacroNamespaceMap<'a>>;
+pub type MacroTemplateMap<'a> = TeraHashMap<&'a str, MacroNamespaceMap<'a>>;
 
 /// Collection of all macro templates by file
 #[derive(Clone, Debug, Default)]
@@ -21,7 +20,7 @@ pub struct MacroCollection<'a> {
 
 impl<'a> MacroCollection<'a> {
     pub fn from_original_template(tpl: &'a Template, tera: &'a Tera) -> MacroCollection<'a> {
-        let mut macro_collection = MacroCollection { macros: MacroTemplateMap::new() };
+        let mut macro_collection = MacroCollection { macros: MacroTemplateMap::default() };
 
         macro_collection
             .add_macros_from_template(tera, tpl)
@@ -46,7 +45,7 @@ impl<'a> MacroCollection<'a> {
             return Ok(());
         }
 
-        let mut macro_namespace_map = MacroNamespaceMap::new();
+        let mut macro_namespace_map = MacroNamespaceMap::default();
 
         if !template.macros.is_empty() {
             macro_namespace_map.insert("self", (template_name, &template.macros));

--- a/src/renderer/tests/square_brackets.rs
+++ b/src/renderer/tests/square_brackets.rs
@@ -93,7 +93,6 @@ fn var_access_by_loop_index_with_set() {
     assert!(res.is_ok());
 }
 
-
 // https://github.com/Keats/tera/issues/754
 #[test]
 fn can_get_value_if_key_contains_period() {
@@ -103,11 +102,7 @@ fn can_get_value_if_key_contains_period() {
     map.insert("Mt. Robson Provincial Park".to_string(), "hello".to_string());
     context.insert("tag_info", &map);
 
-    let res = Tera::one_off(
-        r#"{{ tag_info[name] }}"#,
-        &context,
-        true,
-    );
+    let res = Tera::one_off(r#"{{ tag_info[name] }}"#, &context, true);
     assert!(res.is_ok());
     let res = res.unwrap();
     assert_eq!(res, "hello");

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -1,16 +1,14 @@
 use std::collections::HashMap;
+
 use std::fmt;
 use std::fs::File;
+use std::hash::BuildHasherDefault;
 use std::io::prelude::*;
 use std::path::Path;
 use std::sync::Arc;
 
 use globwalk::glob_builder;
 
-#[cfg(feature = "fxhash")]
-use rustc_hash::FxHasher;
-#[cfg(feature = "fxhash")]
-use std::hash::BuildHasherDefault;
 
 use crate::ast::Block;
 use crate::builtins::filters::{array, common, number, object, string, Filter};
@@ -23,10 +21,12 @@ use crate::template::Template;
 use crate::utils::escape_html;
 
 
-#[cfg(feature = "fxhash")]
-pub type TeraHashMap<K, V> = HashMap<K, V, BuildHasherDefault<FxHasher>>;
-#[cfg(not(feature = "fxhash"))]
-pub type TeraHashMap<K, V> = HashMap<K, V>;
+#[cfg(feature = "ahash")]
+pub type TeraHashMap<K, V> = HashMap<K, V, BuildHasherDefault<ahash::AHasher>>;
+#[cfg(all(feature = "seahash", not(feature = "ahash")))]
+pub type TeraHashMap<K, V> = HashMap<K, V, BuildHasherDefault<seahash::SeaHasher>>;
+#[cfg(all(not(feature = "seahash"), not(feature = "ahash")))]
+pub type TeraHashMap<K, V> = HashMap<K, V, std::collections::hash_map::RandomState>;
 
 /// Default template name used for `Tera::render_str` and `Tera::one_off`.
 const ONE_OFF_TEMPLATE_NAME: &str = "__tera_one_off";


### PR DESCRIPTION
I implemented a switch for the hasher.
I have to admit, i expected more difference by replacing the hashers.
fxhasher was always slower than the deault siphash1-3
seahash was slightly faster
ahash even faster

benchmarks (rust 1.69.0; AMD Ryzen 5 3600 6-Core Processor)
```
cpuflags:
flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl nonstop_tsc cpuid extd_apicid aperfmperf rapl pni pclmulqdq monitor ssse3 fma cx16 sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand lahf_lm cmp_legacy svm extapic cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw ibs skinit wdt tce topoext perfctr_core perfctr_nb bpext perfctr_llc mwaitx cpb cat_l3 cdp_l3 hw_pstate ssbd mba ibpb stibp vmmcall fsgsbase bmi1 avx2 smep bmi2 cqm rdt_a rdseed adx smap clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 xsaves cqm_llc cqm_occup_llc cqm_mbm_total cqm_mbm_local clzero irperf xsaveerptr rdpru wbnoinvd arat npt lbrv svm_lock nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold avic v_vmsave_vmload vgif v_spec_ctrl umip rdpid overflow_recov succor smca sme sev sev_es
```

default hasher:
```
running 4 tests
test bench_big_loop_big_object                 ... bench:     185,212 ns/iter (+/- 1,397)
test bench_macro_big_object                    ... bench:     443,667 ns/iter (+/- 10,166)
test bench_macro_big_object_no_loop_macro_call ... bench:   1,059,355 ns/iter (+/- 179,342)
test bench_macro_big_object_no_loop_with_set   ... bench:   1,045,307 ns/iter (+/- 275,470)

test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured; 0 filtered out; finished in 8.65s

     Running benches/escaping.rs (target/release/deps/escaping-73cdee30956e38a2)

running 6 tests
test bench_escape_html_long         ... bench:         285 ns/iter (+/- 8)
test bench_escape_html_short        ... bench:         116 ns/iter (+/- 3)
test bench_escape_html_very_long    ... bench:       4,132 ns/iter (+/- 71)
test bench_escape_no_html_long      ... bench:         275 ns/iter (+/- 2)
test bench_escape_no_html_short     ... bench:         139 ns/iter (+/- 2)
test bench_escape_no_html_very_long ... bench:       2,337 ns/iter (+/- 47)

test result: ok. 0 passed; 0 failed; 0 ignored; 6 measured; 0 filtered out; finished in 12.41s

     Running benches/json_pointer.rs (target/release/deps/json_pointer-82582d912d61dd99)

running 2 tests
test bench_get_json_pointer          ... bench:         113 ns/iter (+/- 14)
test bench_get_json_pointer_with_map ... bench:         569 ns/iter (+/- 7)

test result: ok. 0 passed; 0 failed; 0 ignored; 2 measured; 0 filtered out; finished in 0.62s

     Running benches/templates.rs (target/release/deps/templates-2b7e84ae09e9002a)

running 2 tests
test big_table ... bench:   1,363,223 ns/iter (+/- 53,975)
test teams     ... bench:       4,599 ns/iter (+/- 1,352)

test result: ok. 0 passed; 0 failed; 0 ignored; 2 measured; 0 filtered out; finished in 6.60s

     Running benches/tera.rs (target/release/deps/tera-c384b6304625628d)

running 12 tests
test access_deep_object                        ... bench:       2,722 ns/iter (+/- 178)
test access_deep_object_with_literal           ... bench:       4,554 ns/iter (+/- 287)
test bench_build_inheritance_chains            ... bench:       2,283 ns/iter (+/- 33)
test bench_huge_loop                           ... bench:     606,631 ns/iter (+/- 25,683)
test bench_parsing_basic_template              ... bench:      44,302 ns/iter (+/- 2,299)
test bench_parsing_with_inheritance_and_macros ... bench:      69,640 ns/iter (+/- 1,650)
test bench_rendering_basic_template            ... bench:       3,684 ns/iter (+/- 183)
test bench_rendering_inheritance_and_macros    ... bench:       4,208 ns/iter (+/- 48)
test bench_rendering_only_inheritance          ... bench:         950 ns/iter (+/- 22)
test bench_rendering_only_macro_call           ... bench:       3,446 ns/iter (+/- 72)
test bench_rendering_only_parent               ... bench:         393 ns/iter (+/- 11)
test bench_rendering_only_variable             ... bench:         763 ns/iter (+/- 31)

test result: ok. 0 passed; 0 failed; 0 ignored; 12 measured; 0 filtered out; finished in 4.76s
```

seahash:
```
running 4 tests
test bench_big_loop_big_object                 ... bench:     188,041 ns/iter (+/- 1,974)
test bench_macro_big_object                    ... bench:     479,234 ns/iter (+/- 14,495)
test bench_macro_big_object_no_loop_macro_call ... bench:   1,036,916 ns/iter (+/- 49,635)
test bench_macro_big_object_no_loop_with_set   ... bench:   1,042,546 ns/iter (+/- 31,172)

test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured; 0 filtered out; finished in 5.65s

     Running benches/escaping.rs (target/release/deps/escaping-472a8cf95f3655a7)

running 6 tests
test bench_escape_html_long         ... bench:         449 ns/iter (+/- 20)
test bench_escape_html_short        ... bench:         153 ns/iter (+/- 26)
test bench_escape_html_very_long    ... bench:       5,801 ns/iter (+/- 824)
test bench_escape_no_html_long      ... bench:         439 ns/iter (+/- 28)
test bench_escape_no_html_short     ... bench:         140 ns/iter (+/- 17)
test bench_escape_no_html_very_long ... bench:       2,036 ns/iter (+/- 112)

test result: ok. 0 passed; 0 failed; 0 ignored; 6 measured; 0 filtered out; finished in 6.56s

     Running benches/json_pointer.rs (target/release/deps/json_pointer-496686c3aa292177)

running 2 tests
test bench_get_json_pointer          ... bench:         113 ns/iter (+/- 4)
test bench_get_json_pointer_with_map ... bench:         566 ns/iter (+/- 11)

test result: ok. 0 passed; 0 failed; 0 ignored; 2 measured; 0 filtered out; finished in 4.15s

     Running benches/templates.rs (target/release/deps/templates-34b6c1f39780406e)

running 2 tests
test big_table ... bench:   1,465,147 ns/iter (+/- 129,177)
test teams     ... bench:       4,478 ns/iter (+/- 186)

test result: ok. 0 passed; 0 failed; 0 ignored; 2 measured; 0 filtered out; finished in 3.50s

     Running benches/tera.rs (target/release/deps/tera-b9432ba01b29c252)

running 12 tests
test access_deep_object                        ... bench:       2,663 ns/iter (+/- 105)
test access_deep_object_with_literal           ... bench:       4,490 ns/iter (+/- 136)
test bench_build_inheritance_chains            ... bench:       2,416 ns/iter (+/- 38)
test bench_huge_loop                           ... bench:     581,415 ns/iter (+/- 8,649)
test bench_parsing_basic_template              ... bench:      45,632 ns/iter (+/- 836)
test bench_parsing_with_inheritance_and_macros ... bench:      71,774 ns/iter (+/- 886)
test bench_rendering_basic_template            ... bench:       3,659 ns/iter (+/- 146)
test bench_rendering_inheritance_and_macros    ... bench:       4,481 ns/iter (+/- 206)
test bench_rendering_only_inheritance          ... bench:       1,082 ns/iter (+/- 46)
test bench_rendering_only_macro_call           ... bench:       3,429 ns/iter (+/- 186)
test bench_rendering_only_parent               ... bench:         432 ns/iter (+/- 11)
test bench_rendering_only_variable             ... bench:         769 ns/iter (+/- 24)

test result: ok. 0 passed; 0 failed; 0 ignored; 12 measured; 0 filtered out; finished in 6.09s
```
ahash:
```
running 4 tests
test bench_big_loop_big_object                 ... bench:     185,088 ns/iter (+/- 4,648)
test bench_macro_big_object                    ... bench:     420,424 ns/iter (+/- 20,706)
test bench_macro_big_object_no_loop_macro_call ... bench:   1,034,711 ns/iter (+/- 61,297)
test bench_macro_big_object_no_loop_with_set   ... bench:   1,042,189 ns/iter (+/- 131,073)

test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured; 0 filtered out; finished in 10.95s

     Running benches/escaping.rs (target/release/deps/escaping-5a248d59bf6a9ff3)

running 6 tests
test bench_escape_html_long         ... bench:         285 ns/iter (+/- 14)
test bench_escape_html_short        ... bench:         128 ns/iter (+/- 20)
test bench_escape_html_very_long    ... bench:       4,185 ns/iter (+/- 118)
test bench_escape_no_html_long      ... bench:         279 ns/iter (+/- 180)
test bench_escape_no_html_short     ... bench:         141 ns/iter (+/- 3)
test bench_escape_no_html_very_long ... bench:       1,377 ns/iter (+/- 19)

test result: ok. 0 passed; 0 failed; 0 ignored; 6 measured; 0 filtered out; finished in 8.79s

     Running benches/json_pointer.rs (target/release/deps/json_pointer-3c476e87b1ab8b2d)

running 2 tests
test bench_get_json_pointer          ... bench:         116 ns/iter (+/- 2)
test bench_get_json_pointer_with_map ... bench:         572 ns/iter (+/- 313)

test result: ok. 0 passed; 0 failed; 0 ignored; 2 measured; 0 filtered out; finished in 0.64s

     Running benches/templates.rs (target/release/deps/templates-0f84921a24cec467)

running 2 tests
test big_table ... bench:   1,379,315 ns/iter (+/- 52,279)
test teams     ... bench:       4,340 ns/iter (+/- 37)

test result: ok. 0 passed; 0 failed; 0 ignored; 2 measured; 0 filtered out; finished in 6.65s

     Running benches/tera.rs (target/release/deps/tera-be1565794554e805)

running 12 tests
test access_deep_object                        ... bench:       2,610 ns/iter (+/- 57)
test access_deep_object_with_literal           ... bench:       4,462 ns/iter (+/- 63)
test bench_build_inheritance_chains            ... bench:       1,962 ns/iter (+/- 71)
test bench_huge_loop                           ... bench:     586,008 ns/iter (+/- 10,612)
test bench_parsing_basic_template              ... bench:      43,286 ns/iter (+/- 517)
test bench_parsing_with_inheritance_and_macros ... bench:      68,317 ns/iter (+/- 815)
test bench_rendering_basic_template            ... bench:       3,561 ns/iter (+/- 97)
test bench_rendering_inheritance_and_macros    ... bench:       3,744 ns/iter (+/- 91)
test bench_rendering_only_inheritance          ... bench:         731 ns/iter (+/- 11)
test bench_rendering_only_macro_call           ... bench:       3,105 ns/iter (+/- 29)
test bench_rendering_only_parent               ... bench:         335 ns/iter (+/- 4)
test bench_rendering_only_variable             ... bench:         728 ns/iter (+/- 12)

test result: ok. 0 passed; 0 failed; 0 ignored; 12 measured; 0 filtered out; finished in 11.04s

```