### PR TITLE
Allow macro definition in renderable template

### DIFF
--- a/docs/content/docs/_index.md
+++ b/docs/content/docs/_index.md
@@ -663,7 +663,10 @@ A macro is called like this:
 ```
 Do note that macros, like filters, require keyword arguments.
 If you are trying to call a macro defined in the same file or itself, you will need to use the `self` namespace.
-The `self` namespace can only be used in macros.
+The `self` namespace can only be used in macros. Macros must be defined top-level (they cannot be nested in an if,
+for, etc.) and should only reference arguments, not template variables directly.
+
+
 Macros can be called recursively but there is no limit to recursion so make sure your macro ends.
 
 Here's an example of a recursive macro:

--- a/docs/content/docs/_index.md
+++ b/docs/content/docs/_index.md
@@ -636,7 +636,6 @@ You can also provide a list of templates that are checked for existence before i
 ### Macros
 
 Think of macros as functions or components that you can call and return some text.
-Macros currently need to be defined in a separate file and imported to be useable.
 
 They are defined as follows:
 
@@ -650,7 +649,7 @@ They are defined as follows:
 ```
 As shown in the example above, macro arguments can have a default [literal](@/docs/_index.md#literals) value.
 
-In order to use them, you need to import the file containing the macros:
+If a macro is defined in a separate file, you need to import the file containing the macros:
 
 ```jinja2
 {% import "macros.html" as macros %}

--- a/docs/content/docs/_index.md
+++ b/docs/content/docs/_index.md
@@ -662,9 +662,7 @@ A macro is called like this:
 {{ macros::input(label="Name", type="text") }}
 ```
 Do note that macros, like filters, require keyword arguments.
-If you are trying to call a macro defined in the same file or itself, you will need to use the `self` namespace.
-The `self` namespace can only be used in macros. Macros must be defined top-level (they cannot be nested in an if,
-for, etc.) and should only reference arguments, not template variables directly.
+Use the `self` namespace when calling a macro defined in the same file. Macros must be defined top-level (they cannot be nested in an if, for, etc.) and should only reference arguments, not template variables directly.
 
 
 Macros can be called recursively but there is no limit to recursion so make sure your macro ends.

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1055,7 +1055,6 @@ fn parse_content(pair: Pair<Rule>) -> TeraResult<Vec<Node>> {
             Rule::set_global_tag => nodes.push(parse_set_tag(p, true)?),
             Rule::raw => nodes.push(parse_raw_tag(p)),
             Rule::variable_tag => nodes.push(parse_variable_tag(p)?),
-            Rule::macro_definition => nodes.push(parse_macro_definition(p)?),
             Rule::forloop => nodes.push(parse_forloop(p)?),
             Rule::break_tag => nodes.push(parse_break_tag(p)),
             Rule::continue_tag => nodes.push(parse_continue_tag(p)),
@@ -1130,7 +1129,7 @@ pub fn parse(input: &str) -> TeraResult<Vec<Node>> {
                     Rule::test_not => "a negated test".to_string(),
                     Rule::test_call => "a test call".to_string(),
                     Rule::test_arg => "a test argument (any expressions including arrays)".to_string(),
-                    Rule::test_args => "a list of test arguments (any expression including arrayss)".to_string(),
+                    Rule::test_args => "a list of test arguments (any expression including arrays)".to_string(),
                     Rule::macro_fn | Rule::macro_fn_wrapper => "a macro function".to_string(),
                     Rule::macro_call => "a macro function call".to_string(),
                     Rule::macro_def_arg => {
@@ -1177,7 +1176,7 @@ pub fn parse(input: &str) -> TeraResult<Vec<Node>> {
                     | Rule::macro_if
                     | Rule::for_if
                     | Rule::filter_section_if => {
-                        "a `if` tag".to_string()
+                        "an `if` tag".to_string()
                     }
                     Rule::elif_tag => "an `elif` tag".to_string(),
                     Rule::else_tag => "an `else` tag".to_string(),
@@ -1214,6 +1213,7 @@ pub fn parse(input: &str) -> TeraResult<Vec<Node>> {
             Rule::extends_tag => nodes.push(parse_extends(p)),
             Rule::import_macro_tag => nodes.push(parse_import_macro(p)),
             Rule::content => nodes.extend(parse_content(p)?),
+            Rule::macro_definition => nodes.push(parse_macro_definition(p)?),
             Rule::comment_tag => (),
             Rule::EOI => (),
             _ => unreachable!("unknown tpl rule: {:?}", p.as_rule()),

--- a/src/parser/tera.pest
+++ b/src/parser/tera.pest
@@ -286,7 +286,6 @@ content = @{
     comment_tag |
     set_tag |
     set_global_tag |
-    macro_definition |
     block |
     content_if |
     forloop |
@@ -316,6 +315,6 @@ template = ${
     SOI
     ~ comment_tag*
     ~ top_imports?
-    ~ content*
+    ~ (content | macro_definition)* // macro_definition must be top-level
     ~ EOI
 }

--- a/src/parser/tests/errors.rs
+++ b/src/parser/tests/errors.rs
@@ -102,6 +102,19 @@ fn invalid_macro_content() {
 }
 
 #[test]
+fn invalid_macro_not_toplevel() {
+    assert_err_msg(
+        r#"
+{% if val %}
+    {% macro input(label, type) %}
+    {% endmacro input %}
+{% endif %}
+    "#,
+        &["3:5", "unexpected tag; expected an `elif` tag, an `else` tag, an endif tag (`{% endif %}`), or some content"],
+    );
+}
+
+#[test]
 fn invalid_macro_default_arg_value() {
     assert_err_msg(
         r#"
@@ -145,7 +158,7 @@ fn invalid_extends_position() {
 hello
 {% extends "hey.html" %}
     "#,
-        &["3:1", "unexpected tag; expected end of input or some content"],
+        &["3:1", "unexpected tag; expected end of input, a macro definition tag (`{% macro my_macro() %}`, or some content"],
     );
 }
 

--- a/src/renderer/processor.rs
+++ b/src/renderer/processor.rs
@@ -1012,10 +1012,8 @@ impl<'a> Processor<'a> {
                     name
                 )));
             }
-            // TODO: make that a compile time error
-            Node::MacroDefinition(_, ref def, _) => {
-                return Err(Error::invalid_macro_def(&def.name));
-            }
+            // Macro definitions are ignored when rendering
+            Node::MacroDefinition(_, _, _) => (),
         };
 
         Ok(())

--- a/src/renderer/tests/errors.rs
+++ b/src/renderer/tests/errors.rs
@@ -204,32 +204,6 @@ fn right_variable_name_is_needed_in_for_loop() {
     );
 }
 
-// https://github.com/Keats/tera/issues/370#issuecomment-453893826
-#[test]
-fn errors_when_calling_macros_defined_in_file() {
-    let mut tera = Tera::default();
-    tera.add_raw_template(
-        "tpl",
-        r#"
-{% macro path_item(path) %}
-    <span class="path" title="{{ path }}">{{ path }}</span>
-{% endmacro path_item %}
-
-...
-
-<td>{{ self::path_item(path=hello) }}</td>
-        "#,
-    )
-    .unwrap();
-    let mut context = Context::new();
-    context.insert("hello", &true);
-    let result = tera.render("tpl", &context);
-    assert_eq!(
-        result.unwrap_err().source().unwrap().to_string(),
-        "Invalid macro definition: `path_item`"
-    );
-}
-
 // https://github.com/Keats/tera/issues/385
 // https://github.com/Keats/tera/issues/370
 #[test]

--- a/src/renderer/tests/macros.rs
+++ b/src/renderer/tests/macros.rs
@@ -21,6 +21,19 @@ fn render_macros() {
 }
 
 #[test]
+fn render_macros_defined_in_template() {
+    let mut tera = Tera::default();
+    tera.add_raw_templates(vec![
+        ("tpl", "{% macro hello()%}Hello{% endmacro hello %}{% block hey %}{{self::hello()}}{% endblock hey %}"),
+    ])
+        .unwrap();
+
+    let result = tera.render("tpl", &Context::new());
+
+    assert_eq!(result.unwrap(), "Hello".to_string());
+}
+
+#[test]
 fn render_macros_expression_arg() {
     let mut context = Context::new();
     context.insert("pages", &vec![1, 2, 3, 4, 5]);


### PR DESCRIPTION
This change refactors the `MacroDefinition` rendering to no-op so that a template may contain a macro definition and still render. The previous behaviour was to error. 

This means I may define a macro in a template and use it with the `self` namespace, as the test shows. It's useful for me to be able to extract some common behaviour in my templates out without having multiple files.

Related issues:
- #821
- #644