### PR TITLE
Fix for square bracket identifiers breaking tests

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -143,7 +143,7 @@ fn parse_test(pair: Pair<Rule>) -> TeraResult<Test> {
 
     for p in pair.into_inner() {
         match p.as_rule() {
-            Rule::dotted_ident => ident = Some(p.as_str().to_string()),
+            Rule::dotted_square_bracket_ident => ident = Some(p.as_str().to_string()),
             Rule::test_call => {
                 let (_name, _args) = parse_test_call(p)?;
                 name = Some(_name);

--- a/src/parser/tera.pest
+++ b/src/parser/tera.pest
@@ -138,8 +138,8 @@ macro_call      = { ident ~ "::" ~ ident ~ "(" ~ kwargs? ~ ")" }
 test_arg  = { logic_expr | array_filter }
 test_args = _{ test_arg ~ ("," ~ test_arg)* }
 test_call = !{ ident ~ ("(" ~ test_args ~ ")")? }
-test_not  = { dotted_ident ~ "is" ~ "not" ~ test_call }
-test      = { dotted_ident ~ "is" ~ test_call }
+test_not  = { dotted_square_bracket_ident ~ "is" ~ "not" ~ test_call }
+test      = { dotted_square_bracket_ident ~ "is" ~ test_call }
 
 // -------------------------------------------------------
 


### PR DESCRIPTION
Feel free to throw out this PR. Seems possible but unlikely that the fix is this simple but I don't know much about what's going on underneath the hood. 

After testing for my uses, this seems to work but I haven't tested any further.