### PR TITLE
chore: update MSRV to 1.63

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [pinned, stable, nightly, macos, win-msvc]
+        build: [msrv, stable, nightly, macos, win-msvc]
         include:
-        - build: pinned
+        - build: msrv
           os: ubuntu-latest
-          rust: 1.56.0
+          rust: 1.63.0
         - build: stable
           os: ubuntu-latest
           rust: stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Minimum supported Rust version (MSRV) is now 1.63 due to transitive dependencies.
+
 ## 1.19.0 (2023-05-31)
 
 - Revert change to glob path to not error if the path doesn't exist

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["template", "html", "django", "markup", "jinja2"]
 categories = ["template-engine"]
 edition = "2018"
 include = ["/src/**/*", "/LICENSE", "/README.md", "/CHANGELOG.md"]
-rust-version = "1.56.0"
+rust-version = "1.63"
 
 [dependencies]
 globwalk = "0.8.1"
@@ -33,14 +33,10 @@ percent-encoding = {version = "2.2", optional = true}
 humansize = {version = "2.1", optional = true}
 # used in date format filter
 chrono = {version = "0.4.23", optional = true, default-features = false, features = ["std", "clock"]}
-# chrono-tz is pinned to Version 0.6.1 for MSRV 1.56.0
-chrono-tz = {version = "=0.6.1", optional = true}
+# used in date format filter
+chrono-tz = {version = "0.8", optional = true}
 # used in get_random function
 rand = {version = "0.8", optional = true}
-
-# thread_local is pinned for MSRV 1.56.0
-[dependencies.thread_local]
-version="=1.1.4"
 
 [dev-dependencies]
 serde_derive = "1.0"


### PR DESCRIPTION
## Motivation

Maintaining such an old MSRV is fighting a losing battle; trust me, I've tried.

(Somewhat hillariously,) Cargo's resolver will prefer to downgrade `tera` versions to allow higher compatible `chrono-tz` & `thread_local` versions. So, this pinning scheme is somewhat fruitless anyway; blocking many users from being able to access newer Tera features and fixes. (This might, in part, explain why download numbers on crates.io still seem to favor of `v1.17.1`.)

```console
 › cargo update
    Updating crates.io index
    Updating chrono-tz v0.6.1 -> v0.6.3
    Updating chrono-tz-build v0.0.2 -> v0.0.3
      Adding humansize v1.1.1
      Adding phf_codegen v0.11.2
      Adding phf_generator v0.11.2
 Downgrading tera v1.19.0 -> v1.17.1
    Updating thread_local v1.1.4 -> v1.1.7
```

## Notes

The concensus among most crates (evidently) and authors is that an MSRV bump is not classed as a breaking change.

I've used 1.63 as the minimal update necessary for builds to succeed without pinning transitive deps. Though, for future-proofing, I'd actually suggest something quite a bit higher like `1.65`, released Nov 2022, so a good support timespan still.

closes #833