### PR TITLE
Fix escaping of backslashes in `_index.md`

### DIFF
--- a/docs/content/docs/_index.md
+++ b/docs/content/docs/_index.md
@@ -240,7 +240,7 @@ Tera has a few literals that can be used:
 - booleans: `true` (or `True`) and `false` (or `False`)
 - integers
 - floats
-- strings: text delimited by `""`, `''` or `` `` ``
+- strings: text delimited by `""`, `''` or ` `` `
 - arrays: a comma-separated list of literals and/or idents surrounded by `[` and `]` (trailing comma allowed)
 
 ### Variables


### PR DESCRIPTION
A single leading and training space character is stripped from [inline code](https://spec.commonmark.org/0.30/#example-330).