### PR TITLE
Optimize `find_value_in_for_loop` when no `Value` is found

### DIFF
--- a/src/renderer/stack_frame.rs
+++ b/src/renderer/stack_frame.rs
@@ -162,14 +162,14 @@ impl<'a> StackFrame<'a> {
 
             // Last case: the variable is/starts with the value name of the for loop
             // The `set` case will have been taken into account before
-            let v = for_loop.get_current_value();
+
             // Exact match to the loop value and no tail
             if key == for_loop.value_name {
-                return Some(v);
+                return Some(for_loop.get_current_value());
             }
 
             if real_key == for_loop.value_name && !tail.is_empty() {
-                return value_by_pointer(tail, &v);
+                return value_by_pointer(tail, &for_loop.get_current_value());
             }
         }
 


### PR DESCRIPTION
In the event that a for loop iterates over `Value`s and also referes to elements not defined by the for loop, `find_value_in_for_loop` would needlessly call `ForLoop::get_current_value` for each of those lookups.

`ForLoop::get_current_value` can be expensive, potentially incurring a clone of a possibly large `Value`.

This change moves the `get_current_value` call so that we only clone a `Value` when needed.