### PR TITLE
Add a "per_render" Context option

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -45,18 +45,39 @@ impl<'a> Renderer<'a> {
         Renderer { template, tera, context, should_escape }
     }
 
-    /// Combines the context with the Template to generate the end result
-    pub fn render(&self) -> Result<String> {
+    /// Combines the context with the Template to generate the end result and choose values unique to this render call
+    pub fn render_with_per_render_context(&self, per_render_context: Context) -> Result<String> {
         let mut output = Vec::with_capacity(2000);
-        self.render_to(&mut output)?;
+        self.render_to_with_per_render_context(&mut output, per_render_context)?;
         buffer_to_string(|| "converting rendered buffer to string".to_string(), output)
     }
 
-    /// Combines the context with the Template to write the end result to output
-    pub fn render_to(&self, mut output: impl Write) -> Result<()> {
-        let mut processor =
-            Processor::new(self.template, self.tera, self.context, self.should_escape);
+    /// Combines the context with the Template to generate the end result
+    pub fn render(&self) -> Result<String> {
+        let empty_context = Context::new();
+        self.render_with_per_render_context(empty_context)
+    }
+
+    /// Combines the context with the Template to write the end result to output and choose values unique to this render call
+    pub fn render_to_with_per_render_context(
+        &self,
+        mut output: impl Write,
+        per_render_context: Context,
+    ) -> Result<()> {
+        let mut processor = Processor::new(
+            self.template,
+            self.tera,
+            self.context,
+            &per_render_context,
+            self.should_escape,
+        );
 
         processor.render(&mut output)
+    }
+
+    /// Combines the context with the Template to write the end result to output
+    pub fn render_to(&self, output: impl Write) -> Result<()> {
+        let empty_context = Context::new();
+        self.render_to_with_per_render_context(output, empty_context)
     }
 }

--- a/src/renderer/processor.rs
+++ b/src/renderer/processor.rs
@@ -124,6 +124,7 @@ impl<'a> Processor<'a> {
         template: &'a Template,
         tera: &'a Tera,
         context: &'a Context,
+        per_render_context: &'a Context,
         should_escape: bool,
     ) -> Self {
         // Gets the root template if we are rendering something with inheritance or just return
@@ -134,7 +135,7 @@ impl<'a> Processor<'a> {
             .map(|parent| tera.get_template(parent).unwrap())
             .unwrap_or(template);
 
-        let call_stack = CallStack::new(context, template);
+        let call_stack = CallStack::new(context, per_render_context, template);
 
         Processor {
             template,


### PR DESCRIPTION
In the case you have a particularly large Context that you can't easily clone, it is useful to have a the ablity to augment the Context on a particular render. By adding an extra context that can be specified on each render call the large Context can be shared with other render calls across multiple threads, thus sidestepping the need to clone and modify the Context for each thread.

I, somewhat aribrary, choose the `per_render_context` to be a fallback context, if the value is not found in the `Context` then look in the `per_render_context`. It might be desirable to check for overlapping keys and error out if they exist.