### PR TITLE
Avoid a Vec allocation

### DIFF
--- a/src/renderer/processor.rs
+++ b/src/renderer/processor.rs
@@ -1002,7 +1002,7 @@ impl<'a> Processor<'a> {
                 }
                 if !found && !ignore_missing {
                     return Err(Error::template_not_found(
-                        vec!["[", &tpl_names.join(", "), "]"].join(""),
+                        ["[", &tpl_names.join(", "), "]"].join(""),
                     ));
                 }
             }


### PR DESCRIPTION
This was found using clippy with `-D clippy::perf`. Since we know the size of the slice at compile time, we can avoid heap allocating a Vec.