### PR TITLE
chore: Bump MSRV to 1.65 for `regex-automata v0.4.3`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         include:
         - build: msrv
           os: ubuntu-latest
-          rust: 1.63.0
+          rust: 1.65.0
         - build: stable
           os: ubuntu-latest
           rust: stable


### PR DESCRIPTION
```
error: package `regex-automata v0.4.3` cannot be built because it requires rustc 1.65 or newer, while the currently active rustc version is 1.63.0
```