### PR TITLE
Bump globwalk dep to 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ include = ["/src/**/*", "/LICENSE", "/README.md", "/CHANGELOG.md"]
 rust-version = "1.65"
 
 [dependencies]
-globwalk = "0.8.1"
+globwalk = "0.9.0"
 serde = "1.0"
 serde_json = "1.0"
 pest = "2.5.5"


### PR DESCRIPTION
Bumps globwalk to version 0.9, mostly to get rid of bitflags 1.* transitive dependecy. (see https://github.com/Gilnaa/globwalk/pull/34)