### PR TITLE
Add context! macro to reduce boilerplate when building Contexts (#861)

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -377,6 +377,23 @@ fn parse_index(s: &str) -> Option<usize> {
 }
 
 /// Creates a context from key value pairs
+///
+/// Example:
+/// ```rust
+/// let ctx = context! {
+///     name => "Brian",
+///     age => &24
+/// };
+/// ```
+/// Expands to:
+/// ```
+/// let ctx = {
+///     let mut context = Context::new();
+///     context.insert("name", "Brian");
+///     context.insert("age", &24);
+///     context
+/// };
+///
 #[macro_export]
 macro_rules! context {
     (

--- a/src/context.rs
+++ b/src/context.rs
@@ -376,6 +376,24 @@ fn parse_index(s: &str) -> Option<usize> {
     s.parse().ok()
 }
 
+/// Creates a context from key value pairs
+#[macro_export]
+macro_rules! context {
+    (
+        $(
+            $key:ident $(=> $value:expr)? $(,)*
+        )*
+    ) => {
+        {
+            let mut context = Context::new();
+            $(
+                context.insert(stringify!($key), $($value)?);
+            )*
+            context
+        }
+    };
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -508,5 +526,19 @@ mod tests {
     fn remove_return_none_with_unknown_index() {
         let mut context = Context::new();
         assert_eq!(context.remove("unknown"), None);
+    }
+
+    #[test]
+    fn context_macro_builder() {
+        let left = context! {
+            foo => "Bar",
+            con => &69
+        };
+
+        let mut right = Context::new();
+        right.insert("foo", "Bar");
+        right.insert("con", &69);
+
+        assert_eq!(left, right);
     }
 }


### PR DESCRIPTION
This macro greatly simplifies building Contexts, as you just pass it key-value pairs and inserts them for you.

Example:
```rust
use tera::context;
let ctx = context! {
    name => "Brian",
    age => &24
};
```

Expands to:
```rust
let ctx = {
    let mut context = Context::new();
    context.insert("name", "Brian");
    context.insert("age", &24);
    context
};
```