### PR TITLE
parser: allocate vector with exact capacity

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1044,9 +1044,10 @@ fn parse_if(pair: Pair<Rule>) -> TeraResult<Node> {
 }
 
 fn parse_content(pair: Pair<Rule>) -> TeraResult<Vec<Node>> {
-    let mut nodes = vec![];
+    let pairs = pair.into_inner();
+    let mut nodes = Vec::with_capacity(pairs.len());
 
-    for p in pair.into_inner() {
+    for p in pairs {
         match p.as_rule() {
             Rule::include_tag => nodes.push(parse_include(p)),
             Rule::comment_tag => nodes.push(parse_comment_tag(p)),


### PR DESCRIPTION
This tweaks `parse_content()` logic in order to reduce the amount of vector growing, as the final vector capacity is already known beforehand.