### PR TITLE
cargo: update MSRV for dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         include:
         - build: msrv
           os: ubuntu-latest
-          rust: 1.65.0
+          rust: 1.70.0
         - build: stable
           os: ubuntu-latest
           rust: stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["template", "html", "django", "markup", "jinja2"]
 categories = ["template-engine"]
 edition = "2018"
 include = ["/src/**/*", "/LICENSE", "/README.md", "/CHANGELOG.md"]
-rust-version = "1.65"
+rust-version = "1.70"
 
 [dependencies]
 globwalk = "0.8.1"


### PR DESCRIPTION
This bumps the MSRV as required by dependencies.
At least `ignore-0.4.22` now requires an higher MSRV in order to use stdlib `OnceLock`.