### PR TITLE
Extends inside include

### DIFF
--- a/docs/content/docs/_index.md
+++ b/docs/content/docs/_index.md
@@ -633,9 +633,6 @@ You can also provide a list of templates that are checked for existence before i
 {% include ["special_sidebar.html", "sidebar.html"] ignore missing %}
 ```
 
-Note: `include` works similar to how it does in other engines like Jinja, with the exception that the current version of Tera doesn't allow inheritance within included files. Practically
-speaking this means you have to choose between using `include`s or `extends` to organise your site, without mixing them. 
-
 ### Macros
 
 Think of macros as functions or components that you can call and return some text.

--- a/src/renderer/call_stack.rs
+++ b/src/renderer/call_stack.rs
@@ -32,6 +32,10 @@ impl<'a> UserContext<'a> {
         let rest = &pointer[root.len() + 1..];
         self.inner.get(&root).and_then(|val| dotted_pointer(val, rest))
     }
+
+    pub fn inner(&self) -> &'a Context {
+        self.inner
+    }
 }
 
 /// Contains the stack of frames
@@ -192,6 +196,10 @@ impl<'a> CallStack<'a> {
     /// Grab the current frame template
     pub fn active_template(&self) -> &'a Template {
         self.current_frame().active_template
+    }
+
+    pub fn current_context(&self) -> &Context {
+        self.context.inner()
     }
 
     pub fn current_context_cloned(&self) -> Value {

--- a/src/renderer/processor.rs
+++ b/src/renderer/processor.rs
@@ -997,6 +997,13 @@ impl<'a> Processor<'a> {
                     self.call_stack.push_include_frame(tpl_name, template);
                     // if include template has parents template (extends) then use Processor
                     if !template.parents.is_empty() {
+                        // check if include template has recursive parent template
+                        if template.parents.contains(&self.template.name) {
+                            return Err(Error::msg(format!(
+                                "Include template ({}) has recursive parent template ({}).",
+                                template.name, self.template.name,
+                            )));
+                        }
                         let mut processor = Processor::new(
                             template,
                             self.tera,

--- a/src/renderer/tests/errors.rs
+++ b/src/renderer/tests/errors.rs
@@ -204,26 +204,6 @@ fn right_variable_name_is_needed_in_for_loop() {
     );
 }
 
-// https://github.com/Keats/tera/issues/385
-// https://github.com/Keats/tera/issues/370
-#[test]
-fn errors_with_inheritance_in_included_template() {
-    let mut tera = Tera::default();
-    tera.add_raw_templates(vec![
-        ("base", "Base - {% include \"child\" %}"),
-        ("parent", "{% block title %}Parent{% endblock %}"),
-        ("child", "{% extends \"parent\" %}{% block title %}{{ super() }} - Child{% endblock %}"),
-    ])
-    .unwrap();
-
-    let result = tera.render("base", &Context::new());
-
-    assert_eq!(
-        result.unwrap_err().source().unwrap().to_string(),
-        "Inheritance in included templates is currently not supported: extended `parent`"
-    );
-}
-
 #[test]
 fn error_string_concat_math_logic() {
     let mut tera = Tera::default();


### PR DESCRIPTION
For issues:

- #385
- #370

- #454
- #592
- #664

- And my personal works.

Changes:

- Exposed current context
- if `template.parents` is not empty 
  - Check and throw error, if include template has recursive parent template (to prevent loop)
  - Using Processor
- else
  - render_body (as it was)
- Removed error test
- Removed `Note` from docs

Here, `tera.get_template(tpl_name)` seems to already parse parents if any exists.
Using `Processor` might create separate context ??
Performance ??