### PR TITLE
Add pad filter

### DIFF
--- a/docs/content/docs/_index.md
+++ b/docs/content/docs/_index.md
@@ -786,6 +786,9 @@ Converts a string to uppercase.
 #### wordcount
 Returns the number of words in a string.
 
+#### pad
+Pad a string to a given length with a given fill character.
+
 #### capitalize
 Returns the string with all its characters lowercased apart from the first char which is uppercased.
 

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -696,6 +696,7 @@ impl Tera {
         self.register_filter("slugify", string::slugify);
         self.register_filter("addslashes", string::addslashes);
         self.register_filter("split", string::split);
+        self.register_filter("pad", string::pad);
         self.register_filter("int", string::int);
         self.register_filter("float", string::float);
 


### PR DESCRIPTION
Adds a new filter called `pad` which pads a given string to a given length with a given fill character (defaults to a space).