### PR TITLE
Adding RenderContext trait so users can provide access to arbitrary structs without converting it all into a Value

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ chrono-tz = {version = "0.9", optional = true}
 rand = {version = "0.8", optional = true}
 
 [dev-dependencies]
+elsa = "1.10.0"
 serde_derive = "1.0"
 pretty_assertions = "1"
 tempfile = "3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ mod utils;
 pub use crate::builtins::filters::Filter;
 pub use crate::builtins::functions::Function;
 pub use crate::builtins::testers::Test;
-pub use crate::context::Context;
+pub use crate::context::{Context, RenderContext};
 pub use crate::errors::{Error, ErrorKind, Result};
 // Template, dotted_pointer and get_json_pointer are meant to be used internally only but is exported for test/bench.
 #[doc(hidden)]

--- a/src/renderer/tests/custom_context.rs
+++ b/src/renderer/tests/custom_context.rs
@@ -1,0 +1,117 @@
+//! These tests demonstrate how to define structs that can be used as a `RenderContext`
+//! one advantage to custom structs here is that we can use borrowed data instead of converting
+//! the entire input into a `Value` which can be expensive.
+
+use std::borrow::Cow;
+
+use elsa::FrozenMap;
+use serde_derive::Serialize;
+use serde_json::Value;
+
+use crate::{Context, RenderContext, Tera};
+
+struct CachingContext<C: RenderContext> {
+    inner: C,
+    value_cache: FrozenMap<String, Box<Option<Value>>>,
+}
+
+impl<C: RenderContext> CachingContext<C> {
+    fn new(inner: C) -> Self {
+        Self { inner, value_cache: FrozenMap::default() }
+    }
+}
+
+impl<C: RenderContext> RenderContext for CachingContext<C> {
+    fn find_value<'k>(&self, key: &'k str) -> Option<Cow<Value>> {
+        if let Some(cached) = self.value_cache.get(key) {
+            cached.as_ref().map(Cow::Borrowed)
+        } else {
+            self.value_cache.insert(
+                key.to_string(),
+                Box::new(self.inner.find_value(key).map(|v| v.into_owned())),
+            );
+            self.value_cache.get(key).map(|v| v.as_ref().map(Cow::Borrowed)).flatten()
+        }
+    }
+
+    fn deep_copy_as_context(&self) -> Context {
+        self.inner.deep_copy_as_context()
+    }
+}
+
+#[derive(Serialize)]
+struct Company<'c> {
+    name: &'c str,
+    address: &'c str,
+}
+
+#[derive(Serialize)]
+struct Customer<'c> {
+    name: &'c str,
+    address: &'c str,
+}
+
+#[derive(Serialize)]
+struct Product<'p> {
+    name: &'p str,
+    sku: &'p str,
+    company: &'p Company<'p>,
+    price_in_cents: u32,
+}
+
+struct Order<'o> {
+    customer: &'o Customer<'o>,
+    product: &'o Product<'o>,
+}
+
+impl<'a> RenderContext for Order<'a> {
+    fn find_value<'k>(&self, key: &'k str) -> Option<Cow<Value>> {
+        match key {
+            "customer.name" => Some(Cow::Owned(Value::String(self.customer.name.to_string()))),
+            "customer.address" => {
+                Some(Cow::Owned(Value::String(self.customer.address.to_string())))
+            }
+            "product.name" => Some(Cow::Owned(Value::String(self.product.name.to_string()))),
+            "product.sku" => Some(Cow::Owned(Value::String(self.product.sku.to_string()))),
+            "product.company.name" => {
+                Some(Cow::Owned(Value::String(self.product.company.name.to_string())))
+            }
+            "product.price_in_cents" => Some(Cow::Owned(self.product.price_in_cents.into())),
+            _ => None,
+        }
+    }
+
+    fn deep_copy_as_context(&self) -> Context {
+        let mut ctx = Context::new();
+        ctx.insert("customer", self.customer);
+        ctx.insert("product", self.product);
+        ctx
+    }
+}
+
+#[test]
+fn test_custom_context() {
+    let company = Company { name: "ACME", address: "123 Main St" };
+    let customer = Customer { name: "John Doe", address: "456 Elm St" };
+    let product = Product { name: "Widget", sku: "W123", company: &company, price_in_cents: 10_00 };
+    let order = Order { customer: &customer, product: &product };
+
+    // Caching context can work on a read only borrow of the order, prevent us from needing to convert on each access
+    let ctx = CachingContext::new(&order);
+
+    let mut tera = Tera::default();
+
+    tera.add_raw_template("shipping_label", "{{ customer.name }}\n{{ customer.address }}")
+        .expect("Unable to compile shipping label template");
+
+    tera.add_raw_template("invoice", "Invoice for {{ product.name }}\nSKU: {{ product.sku }}\nPrice: ${{ product.price_in_cents / 100 }}").expect("Unable to compile invoice template");
+
+    assert_eq!(
+        tera.render("shipping_label", &ctx).expect("Unable to render shipping label"),
+        "John Doe\n456 Elm St"
+    );
+    assert_eq!(
+        tera.render("invoice", &ctx).expect("Unable to render invoice"),
+        "Invoice for Widget\nSKU: W123\nPrice: $10"
+    );
+}

--- a/src/renderer/tests/mod.rs
+++ b/src/renderer/tests/mod.rs
@@ -1,6 +1,7 @@
 use serde_derive::Serialize;
 
 mod basic;
+mod custom_context;
 mod errors;
 mod inheritance;
 mod macros;

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -10,7 +10,7 @@ use globwalk::glob_builder;
 use crate::builtins::filters::{array, common, number, object, string, Filter};
 use crate::builtins::functions::{self, Function};
 use crate::builtins::testers::{self, Test};
-use crate::context::Context;
+use crate::context::RenderContext;
 use crate::errors::{Error, Result};
 use crate::renderer::Renderer;
 use crate::template::Template;
@@ -386,9 +386,9 @@ impl Tera {
     /// let output = tera.render("hello.html", &Context::new()).unwrap();
     /// assert_eq!(output, "<h1>Hello</h1>");
     /// ```
-    pub fn render(&self, template_name: &str, context: &Context) -> Result<String> {
+    pub fn render(&self, template_name: &str, context: impl RenderContext) -> Result<String> {
         let template = self.get_template(template_name)?;
-        let renderer = Renderer::new(template, self, context);
+        let renderer = Renderer::new(template, self, &context);
         renderer.render()
     }
 
@@ -419,7 +419,7 @@ impl Tera {
     pub fn render_to(
         &self,
         template_name: &str,
-        context: &Context,
+        context: impl RenderContext,
         write: impl Write,
     ) -> Result<()> {
         let template = self.get_template(template_name)?;
@@ -440,7 +440,7 @@ impl Tera {
     /// let string = tera.render_str("{{ greeting }} World!", &context)?;
     /// assert_eq!(string, "Hello World!");
     /// ```
-    pub fn render_str(&mut self, input: &str, context: &Context) -> Result<String> {
+    pub fn render_str(&mut self, input: &str, context: impl RenderContext) -> Result<String> {
         self.add_raw_template(ONE_OFF_TEMPLATE_NAME, input)?;
         let result = self.render(ONE_OFF_TEMPLATE_NAME, context);
         self.templates.remove(ONE_OFF_TEMPLATE_NAME);
@@ -459,7 +459,7 @@ impl Tera {
     /// context.insert("greeting", &"hello");
     /// Tera::one_off("{{ greeting }} world", &context, true);
     /// ```
-    pub fn one_off(input: &str, context: &Context, autoescape: bool) -> Result<String> {
+    pub fn one_off(input: &str, context: impl RenderContext, autoescape: bool) -> Result<String> {
         let mut tera = Tera::default();
 
         if autoescape {


### PR DESCRIPTION
I think that this will help users expose more extensive data structures to Tera without needing to recursively convert to a `Value` when rendering.

The existing api should still be compatible because both `Context` and any immutable borrow of a `RenderContext` will implement `RenderContext` so the render calls in tera.rs should still work with `&Context`.

I don't think I've changed any logic for the `Context` rendering.  It is all confined to the `RenderContext` trait definition now though.