### PR TITLE
Introducing Tera Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Crates.io](https://img.shields.io/crates/v/tera.svg)](https://crates.io/crates/tera)
 [![Docs](https://docs.rs/tera/badge.svg)](https://docs.rs/crate/tera/)
 [![Gitter](https://badges.gitter.im/Tera-templates/community.svg)](https://gitter.im/Tera-templates/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Tera%20Guru-006BFF)](https://gurubase.io/g/tera)
 
 Tera is a template engine inspired by [Jinja2](http://jinja.pocoo.org/) and the [Django template language](https://docs.djangoproject.com/en/3.1/topics/templates/).
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Tera Guru](https://gurubase.io/g/tera) to Gurubase. Tera Guru uses the data from this repo and data from the [docs](http://keats.github.io/tera/docs) to answer questions by leveraging the LLM.

In this PR, I showcased the "Tera Guru", which highlights that Tera now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Tera Guru in Gurubase, just let me know that's totally fine.
