### PR TITLE
feat: Make `date` filter work on a RFC3339 string as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.20.1 (2025-03-00)
+
+- Make `date` filter work on a RFC3339 string as well thanks to @blfpd
+
 ## 1.20.0 (2024-05-27)
 
 - Support parenthesis in if statemetns

--- a/docs/content/docs/_index.md
+++ b/docs/content/docs/_index.md
@@ -1217,6 +1217,8 @@ Example:
 {{ "2019-09-19T13:18:48.731Z" | date(format="%Y-%m-%d %H:%M", timezone="Asia/Shanghai") }}
 
 {{ 1648252203 | date(timezone="Europe/Berlin") }}
+
+{{ "Thu, 19 09 2019 13:18:48 GMT" | date(timezone="UTC") }}
 ```
 
 Locale can be specified (excepted when the input is a timestamp without timezone argument), default being POSIX. (only available if the `date-locale` feature is enabled)


### PR DESCRIPTION
Related issue: https://github.com/Keats/tera/issues/959
