### PR TITLE
fix: Prevent the default filter from escaping it's argument twice

### DIFF
--- a/src/renderer/processor.rs
+++ b/src/renderer/processor.rs
@@ -296,7 +296,7 @@ impl<'a> Processor<'a> {
 
     fn get_default_value(&mut self, expr: &'a Expr) -> Result<Val<'a>> {
         if let Some(default_expr) = expr.filters[0].args.get("value") {
-            self.eval_expression(default_expr)
+            self.safe_eval_expression(default_expr)
         } else {
             Err(Error::msg("The `default` filter requires a `value` argument."))
         }

--- a/src/renderer/tests/basic.rs
+++ b/src/renderer/tests/basic.rs
@@ -657,6 +657,8 @@ fn default_filter_works() {
         (r#"{{ not admin | default(value=true) }}"#, "false"),
         (r#"{{ null | default(value=true) }}"#, "true"),
         (r#"{{ null | default(value="hey") | capitalize }}"#, "Hey"),
+        // https://github.com/Keats/tera/issues/969
+        (r#"{{ null | default(value="N/A") }}"#, "N&#x2F;A"),
     ];
 
     for (input, expected) in inputs {


### PR DESCRIPTION
Closes https://github.com/Keats/tera/issues/969

Also adds a test to prevent future regression, and to make sure it's escaped at least once.