### PR TITLE
Update crate rand to v0.10 and crate chrono-tz to v0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,9 +34,9 @@ humansize = {version = "2.1", optional = true}
 # used in date format filter
 chrono = {version = "0.4.27", optional = true, default-features = false, features = ["std", "clock"]}
 # used in date format filter
-chrono-tz = {version = "0.9", optional = true}
+chrono-tz = {version = "0.10", optional = true}
 # used in get_random function
-rand = {version = "0.8", optional = true}
+rand = {version = "0.10", optional = true}
 
 [dev-dependencies]
 serde_derive = "1.0"

--- a/src/builtins/functions.rs
+++ b/src/builtins/functions.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 #[cfg(feature = "builtins")]
 use chrono::prelude::*;
 #[cfg(feature = "builtins")]
-use rand::Rng;
+use rand::RngExt;
 use serde_json::value::{from_value, to_value, Value};
 
 use crate::errors::{Error, Result};
@@ -142,7 +142,7 @@ pub fn throw(args: &HashMap<String, Value>) -> Result<Value> {
 pub fn get_random(args: &HashMap<String, Value>) -> Result<Value> {
     let start = match args.get("start") {
         Some(val) => match from_value::<isize>(val.clone()) {
-            Ok(v) => v,
+            Ok(v) => v as i64,
             Err(_) => {
                 return Err(Error::msg(format!(
                     "Function `get_random` received start={} but `start` can only be a number",
@@ -155,7 +155,7 @@ pub fn get_random(args: &HashMap<String, Value>) -> Result<Value> {
 
     let end = match args.get("end") {
         Some(val) => match from_value::<isize>(val.clone()) {
-            Ok(v) => v,
+            Ok(v) => v as i64,
             Err(_) => {
                 return Err(Error::msg(format!(
                     "Function `get_random` received end={} but `end` can only be a number",
@@ -165,8 +165,8 @@ pub fn get_random(args: &HashMap<String, Value>) -> Result<Value> {
         },
         None => return Err(Error::msg("Function `get_random` didn't receive an `end` argument")),
     };
-    let mut rng = rand::thread_rng();
-    let res = rng.gen_range(start..end);
+    let mut rng = rand::rng();
+    let res = rng.random_range(start..end);
 
     Ok(Value::Number(res.into()))
 }


### PR DESCRIPTION
`cargo audit` currently fails on master branch.

```sh
$ cargo audit
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 1049 security advisories (from /home/theus/.cargo/advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (125 crate dependencies)
Crate:     rand
Version:   0.8.5
Warning:   unsound
Title:     Rand is unsound with a custom logger using `rand::rng()`
Date:      2026-04-09
ID:        RUSTSEC-2026-0097
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0097
Dependency tree:
rand 0.8.5
├── tera 1.20.1
└── phf_generator 0.11.3
    └── phf_codegen 0.11.3
        └── chrono-tz-build 0.3.0
            └── chrono-tz 0.9.0
                └── tera 1.20.1

warning: 1 allowed warning found
```

This updates rand to v0.10 and also chrono-tz to v0.10 as version 0.9 also depends on a vulnerable rand version.

Closes: #989 