### PR TITLE
Added get_component_names and contains_component_definition.

### DIFF
--- a/tera/src/tera.rs
+++ b/tera/src/tera.rs
@@ -428,6 +428,30 @@ impl Tera {
             .map(|(def, _)| ComponentInfo::from(def))
     }
 
+    /// Lookups a component by name, returning whether it's found or not
+    pub fn contains_component_definition(&self, component_name: &str) -> bool {
+        self.get_component_definition(component_name).is_some()
+    }
+
+    /// Returns an iterator over the names of all registered components in an
+    /// unspecified order.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tera::Tera;
+    ///
+    /// let mut tera = Tera::default();
+    /// tera.add_raw_template("foo", "{% component hello(name) %}{{ name }}{% endcomponent %}");
+    ///
+    /// let names: Vec<_> = tera.get_component_names().collect();
+    /// assert_eq!(names.len(), 1);
+    /// assert!(names.contains(&"hello"));
+    /// ```
+    pub fn get_component_names(&self) -> impl Iterator<Item = &str> {
+        self.components.keys().map(|s| s.as_str())
+    }
+
     fn register_builtin_filters(&mut self) {
         self.register_filter("safe", crate::filters::safe);
         self.register_filter("default", crate::filters::default);

--- a/tera/src/tera.rs
+++ b/tera/src/tera.rs
@@ -429,7 +429,21 @@ impl Tera {
     }
 
     /// Lookups a component by name, returning whether it's found or not
-    pub fn contains_component_definition(&self, component_name: &str) -> bool {
+    /// Returns `fakse` if no component with the given name is found.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tera::Tera;
+    /// let mut tera = Tera::default();
+    /// tera.add_raw_template(
+    ///     "components.html",
+    ///     r#"{% component Button(label: String, variant="primary") %}<button>{{ label }}</button>{% endcomponent Button %}"#,
+    /// ).unwrap();
+    ///
+    /// assert!(tera.contains_component("Button"));
+    /// ```
+    pub fn contains_component(&self, component_name: &str) -> bool {
         self.get_component_definition(component_name).is_some()
     }
 


### PR DESCRIPTION
I needed to get the names of all components that are registered. This pull request adds similar methods to the ones that exist for getting templates without exposing the components. 

Hope this looks good to you. 