### PR TITLE
fix regression with the next-generation trait solver

### DIFF
--- a/tera/src/tera.rs
+++ b/tera/src/tera.rs
@@ -310,7 +310,8 @@ impl Tera {
         Arg: for<'a> ArgFromValue<'a>,
         Res: FunctionResult,
     {
-        self.filters.insert(name.into(), StoredFilter::new(filter));
+        self.filters
+            .insert(name.into(), StoredFilter::new::<_, Arg, _>(filter));
     }
 
     /// Register a test with Tera.
@@ -328,7 +329,8 @@ impl Tera {
         Arg: for<'a> ArgFromValue<'a>,
         Res: TestResult,
     {
-        self.tests.insert(name.into(), StoredTest::new(test));
+        self.tests
+            .insert(name.into(), StoredTest::new::<_, Arg, _>(test));
     }
 
     /// Register a function with Tera.


### PR DESCRIPTION
Hi there :wave: unfortunately `tera-2.0.0` currently relies on a type system bug. This code will break with `-Znext-solver` (https://rust-lang.github.io/rust-project-goals/2026/next-solver.html). We're currently rewriting the trait solver of Rust and are close to getting that merged. This change will break code which previously incorrectly compiled.

Luckily this only affects `2.0`. I would really appreciate if you could do a point-release with this fix. Please say if there are any questions.

## More details

This crate currently relies on incorrect type inference, our issue to track that change is https://github.com/rust-lang/trait-system-refactor-initiative/issues/168. Let's look at a minimization of this breakage: https://rust.godbolt.org/z/nTP75En5e

```rust
struct Tera;

pub trait Filter<Arg, Res>: Sync + Send + 'static {}
pub trait ArgFromValue<'k> {
    type Output;
}

struct StoredFilter;
impl StoredFilter {
    pub fn new<Func, Arg, Res>(f: Func)
    where
        Func: Filter<Arg, Res> + for<'a> Filter<<Arg as ArgFromValue<'a>>::Output, Res>,
        Arg: for<'a> ArgFromValue<'a>,
    {
    }
}
fn register_filter<Func, Arg, Res>(
    filter: Func,
) where
    Func: Filter<Arg, Res> + for<'a> Filter<<Arg as ArgFromValue<'a>>::Output, Res>,
    Arg: for<'a> ArgFromValue<'a>,
{
    StoredFilter::new(filter);
}
```


The call to `StoredFilter::new` starts out with `Func` and `Args` being unconstrained inference variables, let's call them `?f` and `?a`. `?f` then gets constrained to the `Func` parameter from `generic_caller`. This leaves us with the following trait bounds: 
- `?a: for<'a> ArgFromValue<'a>`
- `Func: for<'a> Filter<<?a as ArgFromValue<'a>>::Output>`
- `Func: Filter<?a>`

One of these bounds has to constrain `?a` to the `Arg` parameter for this to compile. `?a: for<'a> ArgFromValue'a>` cannot do so, so we're left with the `Func: Filter` bounds.

---

`Func: Filter<?a>` can be proven by either using the `Func: for<'a> Filter<<Arg as ArgFromValue'a>>::Output>` or the `Func: Filter<Arg>` where-bound of `generic_caller`. The first instantiates `?a` with `<<Arg as ArgAsValue<'a>>::Output`, the second with `Arg`. As both where-bounds are valid, this remains ambiguous.

---

`Func: for<'a> Filter<<?a as ArgFromValue'a>>::Output>` can *in theory* also be proven by using both where-bounds of `generic_caller`. The fact that `Func: for<'a> Filter<<Arg as ArgAsValue<'a>>::Output>` may apply should be clear, but `Func: Filter<Arg>` is also totally valid. We'd just need to instantiate `?a` with some type `T` for which `<T as ArgFromValue'a>>::Output` normalizes to `Arg`.

What's even more subtle is that even if we use the `Func: for<'a> Filter<<Arg as ArgFromValue'a>>::Output>` where-bound to to prove `Func: for<'a> Filter<<?a as ArgFromValue'a>>::Output>`, this does not necessarily have to constrain `?a` to `Arg`. It would also be valid to instantiate `?a` with some type `T != Arg` for which `<T as ArgFromValue'a>>::Output` normalizes to `<Arg as ArgFromValue'a>>::Output>`.

---

The current type system implementation incorrectly relates associated types structurally, i.e. by simply checking that their generic arguments are equal, if these associated types reference higher ranked regions, the `'a` from `for<'a>`. This can result in a lot of weird errors and questionable inference behavior, see https://github.com/rust-lang/trait-system-refactor-initiative/issues/9 for an example. Trying to support this behavior with the new implementation is pretty much impossible without adding explicit hacks for each individual breakage. 

See https://github.com/rust-lang/trait-system-refactor-initiative/issues/195 and https://github.com/rust-lang/trait-system-refactor-initiative/issues/168 for more details about the breakage. This has also affected `bevy` and `minijinja` who have used a very similar pattern https://github.com/mitsuhiko/minijinja/pull/787 https://github.com/bevyengine/bevy/pull/18840