### PR TITLE
ci: disable checkout credential persistence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,8 @@ jobs:
             rust: stable
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
@@ -55,4 +57,3 @@ jobs:
         run: cargo test
       - name: tests without the default feature
         run: cargo test --all-features
-


### PR DESCRIPTION
(opened by mistake; I wrote a script which didn't filter forks out, sorry)