### PR TITLE
Support negative component default values

### DIFF
--- a/tera/src/parsing/parser.rs
+++ b/tera/src/parsing/parser.rs
@@ -14,7 +14,7 @@ use crate::parsing::ast::{
 use crate::parsing::ast::{BinaryOperator, Node, UnaryOperator};
 use crate::parsing::lexer::{Token, tokenize};
 use crate::utils::{Span, Spanned};
-use crate::value::{Key, Value};
+use crate::value::{Key, Value, ValueInner};
 use crate::{HashMap, HashSet};
 
 /// Maximum recursion depth for the parser, shared between expression and statement parsing
@@ -731,7 +731,27 @@ impl<'a> Parser<'a> {
                 let (_, r_bp) = unary_binding_power(op);
                 let expr = self.inner_parse_expression(r_bp)?;
                 span.expand(&self.current_span);
-                Expression::UnaryOperation(Spanned::new(UnaryOperation { op, expr }, span.clone()))
+                match (op, &expr) {
+                    (UnaryOperator::Minus, Expression::Const(value)) => match value.node().inner {
+                        ValueInner::I64(value) => Expression::Const(Spanned::new(
+                            Value::from(value.checked_neg().ok_or_else(|| {
+                                Error::syntax_error("Integer overflow".to_string(), &span)
+                            })?),
+                            span.clone(),
+                        )),
+                        ValueInner::F64(value) => {
+                            Expression::Const(Spanned::new(Value::from(-value), span.clone()))
+                        }
+                        _ => Expression::UnaryOperation(Spanned::new(
+                            UnaryOperation { op, expr },
+                            span.clone(),
+                        )),
+                    },
+                    _ => Expression::UnaryOperation(Spanned::new(
+                        UnaryOperation { op, expr },
+                        span.clone(),
+                    )),
+                }
             }
             Token::Ident(ident) => self.parse_ident(ident)?,
             Token::LessThan => {
@@ -1318,6 +1338,19 @@ impl<'a> Parser<'a> {
                     Some(Ok((Token::String(b), _))) => (Value::from(b.clone()), true),
                     Some(Ok((Token::Integer(b), _))) => (Value::from(*b), true),
                     Some(Ok((Token::Float(b), _))) => (Value::from(*b), true),
+                    Some(Ok((Token::Minus, _))) => {
+                        self.next_or_error()?;
+                        match &self.next {
+                            Some(Ok((Token::Integer(b), _))) => (Value::from(-*b), true),
+                            Some(Ok((Token::Float(b), _))) => (Value::from(-*b), true),
+                            _ => {
+                                return Err(Error::syntax_error(
+                                    "Found `-` but component default arguments can only be one of: string, bool, integer, float, array or map".to_string(),
+                                    &self.current_span,
+                                ));
+                            }
+                        }
+                    }
                     Some(Ok((
                         Token::Ident("none") | Token::Ident("None") | Token::Ident("null"),
                         _,

--- a/tera/src/snapshot_tests/parser.rs
+++ b/tera/src/snapshot_tests/parser.rs
@@ -141,6 +141,25 @@ fn parser_can_convert_array_to_const_when_possible() {
 }
 
 #[test]
+fn parser_folds_negative_numbers_to_constants() {
+    let parser = Parser::new("", r#"{{ [-1, {"value": -1.5}] }}"#, Delimiters::default());
+    let nodes = parser.parse().unwrap().nodes;
+    let expected = Value::from(vec![
+        Value::from(-1),
+        Value::from(std::collections::BTreeMap::from([("value", -1.5)])),
+    ]);
+    match &nodes[0] {
+        Node::Expression(e) => {
+            assert_eq!(
+                e,
+                &Expression::Const(Spanned::new(expected, e.span().clone()))
+            );
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
 fn parser_templates_success() {
     insta::glob!("parser_inputs/success/tpl/*.txt", |path| {
         println!("{path:?}");

--- a/tera/src/snapshot_tests/rendering_inputs/success/components/default_args.txt
+++ b/tera/src/snapshot_tests/rendering_inputs/success/components/default_args.txt
@@ -1,4 +1,4 @@
 $$ components
-{% component hello(val=1) %}{{val}}{% endcomponent hello %}
+{% component hello(integer=-1, float=-1.5, positive_array=[1], negative_array=[-1], negative_map={"foo": -1}) %}{{integer}} {{float}} {{positive_array}} {{negative_array}} {{negative_map.foo}}{% endcomponent hello %}
 $$ tpl
 {{<hello/>}}

--- a/tera/src/snapshot_tests/snapshots/tera__snapshot_tests__parser__parser_expressions_success@expressions.txt.snap
+++ b/tera/src/snapshot_tests/snapshots/tera__snapshot_tests__parser__parser_expressions_success@expressions.txt.snap
@@ -1,14 +1,13 @@
 ---
 source: tera/src/snapshot_tests/parser.rs
-assertion_line: 35
 expression: Expressions(expr_nodes)
 input_file: tera/src/snapshot_tests/parser_inputs/success/expr/expressions.txt
 ---
-(- 1)
+-1
 1
 'hello'
 true
-(- 1.2)
+-1.2
 1.2
 a
 (- a)
@@ -26,7 +25,7 @@ hello.data[var].hey
 [(+ 1 1), 2, (* 3 2)]
 (~ hey ho)
 (~ 1 ho)
-(~ (- 1.2) ho)
+(~ -1.2 ho)
 (~ [] ho)
 (~ 'hey' ho)
 (~ (~ 'hello' ident) 'ho')
@@ -97,7 +96,7 @@ three' indent{})
 (== a null)
 (+ 1 (| 2 round{}))
 (== a (| b upper{}))
-(** (- 2) 2)
+(** -2 2)
 (** 2 (** 3 2))
 (not (== a b))
 (not (in (* a b) c))

--- a/tera/src/snapshot_tests/snapshots/tera__snapshot_tests__parser__parser_expressions_success@indexing.txt.snap
+++ b/tera/src/snapshot_tests/snapshots/tera__snapshot_tests__parser__parser_expressions_success@indexing.txt.snap
@@ -4,18 +4,18 @@ expression: Expressions(expr_nodes)
 input_file: tera/src/snapshot_tests/parser_inputs/success/expr/indexing.txt
 ---
 array[0]
-array[(- 1)]
+array[-1]
 array[:2]
 array[1:2]
 array[1:2:2]
-array[:(- 1)]
+array[:-1]
 array?[0]
-array?[(- 1)]
+array?[-1]
 array?[:2]
 array?[1:2]
 array?[1:2:2]
-array?[:(- 1)]
+array?[:-1]
 (| array reverse{})[0]
 range{end=5}[2]
 numbers[0]
-(| (| array reverse{})[:(- 1)] first{})
+(| (| array reverse{})[:-1] first{})

--- a/tera/src/snapshot_tests/snapshots/tera__snapshot_tests__rendering__rendering_components_ok@default_args.txt.snap
+++ b/tera/src/snapshot_tests/snapshots/tera__snapshot_tests__rendering__rendering_components_ok@default_args.txt.snap
@@ -3,4 +3,4 @@ source: tera/src/snapshot_tests/rendering.rs
 expression: "&out"
 input_file: tera/src/snapshot_tests/rendering_inputs/success/components/default_args.txt
 ---
-1
+-1 -1.5 [1] [-1] -1

--- a/tera/tests/introspection.rs
+++ b/tera/tests/introspection.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use tera::{ComponentArgType, Tera, Value};
 
@@ -40,6 +40,42 @@ fn test_get_component_definition() {
     assert_eq!(meta.get("deprecated").unwrap(), &Value::from(true));
 
     assert!(tera.get_component_definition("DoesNotExist").is_none());
+}
+
+#[test]
+fn negative_component_defaults_preserve_value_and_type() {
+    let mut tera = Tera::default();
+    tera.add_raw_template(
+        "components.html",
+        r#"{% component Metrics(integer=-1, float=-1.5, positive_array=[1], negative_array=[-1], negative_map={"foo": -1}) %}{% endcomponent Metrics %}"#,
+    )
+    .unwrap();
+
+    let info = tera.get_component_definition("Metrics").unwrap();
+    let args: HashMap<_, _> = info.args().iter().map(|arg| (arg.name(), arg)).collect();
+
+    let integer = args.get("integer").unwrap();
+    assert_eq!(integer.arg_type(), Some(ComponentArgType::Integer));
+    assert_eq!(integer.default(), Some(&Value::from(-1)));
+
+    let float = args.get("float").unwrap();
+    assert_eq!(float.arg_type(), Some(ComponentArgType::Float));
+    assert_eq!(float.default(), Some(&Value::from(-1.5)));
+
+    let positive_array = args.get("positive_array").unwrap();
+    assert_eq!(positive_array.arg_type(), Some(ComponentArgType::Array));
+    assert_eq!(positive_array.default(), Some(&Value::from(vec![1])));
+
+    let negative_array = args.get("negative_array").unwrap();
+    assert_eq!(negative_array.arg_type(), Some(ComponentArgType::Array));
+    assert_eq!(negative_array.default(), Some(&Value::from(vec![-1])));
+
+    let negative_map = args.get("negative_map").unwrap();
+    assert_eq!(negative_map.arg_type(), Some(ComponentArgType::Map));
+    assert_eq!(
+        negative_map.default(),
+        Some(&Value::from(BTreeMap::from([("foo", -1)])))
+    );
 }
 
 #[test]


### PR DESCRIPTION
### Changes

- accept negative integer and float literals as component definition defaults
- preserve each default's value and inferred argument type
- add rendering and introspection regression coverage

Fixes #1009.

### Verification

- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` (115 passed)
- `cargo test --all-features` (171 passed)
- focused rendering and introspection regressions
- `git diff --check`
