### PR TITLE
Add configurable indent character

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -902,7 +902,7 @@ need to call the `safe` filter after `newlines_to_br`.
 ##### indent
 Indents a string by injecting a prefix at the start of each line.
 The `width` argument (default `4`) specifies how many indent characters to insert per line.
-The `char` argument (default `" "`) specifies the indent character, such as `"\t"` for a tab.
+The `indentation` argument (default `" "`) specifies the indent character, such as `"\t"` for a tab.
 If the `first` argument (default `false`) is set `true`, the prefix is inserted for the first line.
 If the `blank` argument (default `false`) is set `true`, the prefix is inserted for blank/whitespace lines.
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -901,9 +901,10 @@ need to call the `safe` filter after `newlines_to_br`.
 
 ##### indent
 Indents a string by injecting a prefix at the start of each line.
-The `width` argument (default `4`) specifies how many spaces to insert per line.
-If the `first` argument (default `false`) is set `true`, spaces are inserted for the first line.
-If the `blank` argument (default `false`) is set `true`, spaces are inserted for blank/whitespace lines.
+The `width` argument (default `4`) specifies how many indent characters to insert per line.
+The `char` argument (default `" "`) specifies the indent character, such as `"\t"` for a tab.
+If the `first` argument (default `false`) is set `true`, the prefix is inserted for the first line.
+If the `blank` argument (default `false`) is set `true`, the prefix is inserted for blank/whitespace lines.
 
 ##### first
 Returns the first element of an array.

--- a/tera/src/filters.rs
+++ b/tera/src/filters.rs
@@ -246,13 +246,20 @@ pub(crate) fn truncate(val: &str, kwargs: Kwargs, _: &State) -> TeraResult<Strin
 
 /// Return a copy of the string with each line indented by 4 spaces.
 /// The first line and blank lines are not indented by default.
+/// The indent character defaults to a space.
 /// Max width of 1000 to avoid DOS
 pub(crate) fn indent(val: &str, kwargs: Kwargs, _: &State) -> TeraResult<String> {
     let width = kwargs.get::<usize>("width")?.unwrap_or(4).min(1000);
+    let character = kwargs.get::<&str>("char")?.unwrap_or(" ");
+    let mut characters = character.chars();
+    let character = characters
+        .next()
+        .filter(|_| characters.next().is_none())
+        .ok_or_else(|| Error::message("The `char` argument must contain exactly one character"))?;
     let indent_first_line = kwargs.get::<bool>("first")?.unwrap_or(false);
     let indent_blank_line = kwargs.get::<bool>("blank")?.unwrap_or(false);
 
-    let indent = " ".repeat(width);
+    let indent = character.to_string().repeat(width);
     let mut res = String::with_capacity(val.len() * 2);
 
     let mut first_line = true;
@@ -663,6 +670,20 @@ mod tests {
             as_str(map.into(), Kwargs::default(), &state),
             r#"{"hello": "world", "other": 2}"#
         );
+    }
+
+    #[test]
+    fn test_indent_character() {
+        let ctx = Context::new();
+        let state = State::new(&ctx);
+
+        let kwargs = Kwargs::from([("width", 2.into()), ("char", "·".into())]);
+        assert_eq!(indent("one\ntwo", kwargs, &state).unwrap(), "one\n··two");
+
+        for character in ["", "ab"] {
+            let kwargs = Kwargs::from([("char", character.into())]);
+            assert!(indent("one\ntwo", kwargs, &state).is_err());
+        }
     }
 
     #[test]

--- a/tera/src/filters.rs
+++ b/tera/src/filters.rs
@@ -250,16 +250,18 @@ pub(crate) fn truncate(val: &str, kwargs: Kwargs, _: &State) -> TeraResult<Strin
 /// Max width of 1000 to avoid DOS
 pub(crate) fn indent(val: &str, kwargs: Kwargs, _: &State) -> TeraResult<String> {
     let width = kwargs.get::<usize>("width")?.unwrap_or(4).min(1000);
-    let character = kwargs.get::<&str>("char")?.unwrap_or(" ");
-    let mut characters = character.chars();
-    let character = characters
+    let indentation = kwargs.get::<&str>("indentation")?.unwrap_or(" ");
+    let mut characters = indentation.chars();
+    let indent_character = characters
         .next()
         .filter(|_| characters.next().is_none())
-        .ok_or_else(|| Error::message("The `char` argument must contain exactly one character"))?;
+        .ok_or_else(|| {
+            Error::message("The `indentation` argument must contain exactly one character")
+        })?;
     let indent_first_line = kwargs.get::<bool>("first")?.unwrap_or(false);
     let indent_blank_line = kwargs.get::<bool>("blank")?.unwrap_or(false);
 
-    let indent = character.to_string().repeat(width);
+    let indent = indent_character.to_string().repeat(width);
     let mut res = String::with_capacity(val.len() * 2);
 
     let mut first_line = true;
@@ -673,15 +675,15 @@ mod tests {
     }
 
     #[test]
-    fn test_indent_character() {
+    fn test_indent_indentation() {
         let ctx = Context::new();
         let state = State::new(&ctx);
 
-        let kwargs = Kwargs::from([("width", 2.into()), ("char", "·".into())]);
+        let kwargs = Kwargs::from([("width", 2.into()), ("indentation", "·".into())]);
         assert_eq!(indent("one\ntwo", kwargs, &state).unwrap(), "one\n··two");
 
-        for character in ["", "ab"] {
-            let kwargs = Kwargs::from([("char", character.into())]);
+        for indentation in ["", "ab"] {
+            let kwargs = Kwargs::from([("indentation", indentation.into())]);
             assert!(indent("one\ntwo", kwargs, &state).is_err());
         }
     }

--- a/tera/src/snapshot_tests/rendering_inputs/success/filters.txt
+++ b/tera/src/snapshot_tests/rendering_inputs/success/filters.txt
@@ -43,7 +43,7 @@ indent2:{{ "one\ntwo\nthree" | indent(first=true, width=2) }}
 indent3:{{ "one\ntwo\nthree\n\n" | indent(blank=true) }}
 indent4:{{ "a\nb\n" | indent }}END
 indent5:{{ "a\n" | indent(blank=true) }}END
-indent6:{{ "one\ntwo\nthree" | indent(first=true, width=1, char="\t") }}
+indent6:{{ "one\ntwo\nthree" | indent(first=true, width=1, indentation="\t") }}
 {{ "name" | read_ctx }}
 {{ "vectors.1.2" | read_ctx }}
 {{ "objects.0.label" | read_ctx }}

--- a/tera/src/snapshot_tests/rendering_inputs/success/filters.txt
+++ b/tera/src/snapshot_tests/rendering_inputs/success/filters.txt
@@ -43,6 +43,7 @@ indent2:{{ "one\ntwo\nthree" | indent(first=true, width=2) }}
 indent3:{{ "one\ntwo\nthree\n\n" | indent(blank=true) }}
 indent4:{{ "a\nb\n" | indent }}END
 indent5:{{ "a\n" | indent(blank=true) }}END
+indent6:{{ "one\ntwo\nthree" | indent(first=true, width=1, char="\t") }}
 {{ "name" | read_ctx }}
 {{ "vectors.1.2" | read_ctx }}
 {{ "objects.0.label" | read_ctx }}

--- a/tera/src/snapshot_tests/snapshots/tera__snapshot_tests__rendering__rendering_ok@filters.txt.snap
+++ b/tera/src/snapshot_tests/snapshots/tera__snapshot_tests__rendering__rendering_ok@filters.txt.snap
@@ -59,6 +59,9 @@ indent4:a
 END
 indent5:a
 END
+indent6:	one
+	two
+	three
 Bob
 7
 Child


### PR DESCRIPTION
Closes #1007

Adds an optional `char` argument to the built-in `indent` filter while preserving the existing four-space default. The value must contain exactly one Unicode character, so the existing width cap continues to bound output expansion.

The rendering snapshot covers tab indentation, unit tests cover a non-ASCII character plus empty/multi-character rejection, and the filter reference documents the new option.

Validation:
- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo test --all-features`
- `zola build`