### PR TITLE
Add chained filter sections

### DIFF
--- a/tera/src/parsing/ast.rs
+++ b/tera/src/parsing/ast.rs
@@ -2,7 +2,6 @@ use std::collections::{BTreeMap, HashSet};
 use std::fmt;
 use std::str::FromStr;
 
-use crate::HashMap;
 use crate::errors::Error;
 use crate::utils::{Span, Spanned};
 use crate::value::{Key, Value, ValueInner, format_map};
@@ -255,11 +254,11 @@ impl fmt::Display for Expression {
     }
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Filter {
     pub expr: Expression,
     pub name: String,
-    pub kwargs: HashMap<String, Expression>,
+    pub kwargs: BTreeMap<String, Expression>,
 }
 
 impl fmt::Display for Filter {
@@ -277,21 +276,6 @@ impl fmt::Display for Filter {
             }
         }
         write!(f, "}})",)
-    }
-}
-
-impl fmt::Debug for Filter {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let Self { expr, name, kwargs } = &self;
-
-        // Ensures `Debug` output is stable in `insta` snapshot tests
-        let sorted_kwargs: BTreeMap<_, _> = kwargs.iter().collect();
-
-        f.debug_struct(stringify!(Filter))
-            .field("expr", expr)
-            .field("name", name)
-            .field("kwargs", &sorted_kwargs)
-            .finish()
     }
 }
 
@@ -413,7 +397,7 @@ impl Array {
 pub struct Test {
     pub expr: Expression,
     pub name: String,
-    pub kwargs: HashMap<String, Expression>,
+    pub kwargs: BTreeMap<String, Expression>,
 }
 
 impl fmt::Display for Test {
@@ -478,7 +462,7 @@ impl fmt::Display for ComponentCall {
 #[derive(Clone, Debug, PartialEq)]
 pub struct FunctionCall {
     pub name: String,
-    pub kwargs: HashMap<String, Expression>,
+    pub kwargs: BTreeMap<String, Expression>,
 }
 
 impl fmt::Display for FunctionCall {

--- a/tera/src/parsing/ast.rs
+++ b/tera/src/parsing/ast.rs
@@ -255,7 +255,7 @@ impl fmt::Display for Expression {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub struct Filter {
     pub expr: Expression,
     pub name: String,
@@ -277,6 +277,21 @@ impl fmt::Display for Filter {
             }
         }
         write!(f, "}})",)
+    }
+}
+
+impl fmt::Debug for Filter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self { expr, name, kwargs } = &self;
+
+        // Ensures `Debug` output is stable in `insta` snapshot tests
+        let sorted_kwargs: BTreeMap<_, _> = kwargs.iter().collect();
+
+        f.debug_struct(stringify!(Filter))
+            .field("expr", expr)
+            .field("name", name)
+            .field("kwargs", &sorted_kwargs)
+            .finish()
     }
 }
 

--- a/tera/src/parsing/ast.rs
+++ b/tera/src/parsing/ast.rs
@@ -633,9 +633,9 @@ pub struct If {
 /// A filter section node `{% filter name(param="value") %} content {% endfilter %}`
 #[derive(Clone, Debug, PartialEq)]
 pub struct FilterSection {
-    pub name: Spanned<String>,
-    pub kwargs: HashMap<String, Expression>,
-    /// The filter body
+    /// The filters to apply to the body
+    pub filters: Vec<Expression>,
+    /// The filter section body
     pub body: Vec<Node>,
 }
 

--- a/tera/src/parsing/compiler.rs
+++ b/tera/src/parsing/compiler.rs
@@ -619,16 +619,21 @@ impl Compiler {
                 for node in f.body {
                     self.compile_node(node);
                 }
-                self.chunk
-                    .add(Instruction::EndCapture, Some(f.name.span().clone()));
-                self.compile_kwargs(f.kwargs);
-                let (filter_name, span) = f.name.into_parts();
-                self.filter_calls
-                    .entry(filter_name.clone())
-                    .or_default()
-                    .push(span.clone());
-                self.chunk
-                    .add(Instruction::ApplyFilter(filter_name), Some(span));
+                // We can only have an error on a filter so point to the first one
+                let capture_span = f.filters.first().map(|f| f.span().clone());
+                self.chunk.add(Instruction::EndCapture, capture_span);
+                for expr in f.filters {
+                    if let Expression::Filter(f) = expr {
+                        let (filter, span) = f.into_parts();
+                        self.compile_kwargs(filter.kwargs);
+                        self.filter_calls
+                            .entry(filter.name.clone())
+                            .or_default()
+                            .push(span.clone());
+                        self.chunk
+                            .add(Instruction::ApplyFilter(filter.name), Some(span));
+                    }
+                }
                 self.chunk.add(Instruction::WriteTop, None);
             }
         }

--- a/tera/src/parsing/compiler.rs
+++ b/tera/src/parsing/compiler.rs
@@ -1,6 +1,6 @@
 //! AST -> bytecode
 
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 
 use crate::HashMap;
 use crate::parsing::ast::{
@@ -58,7 +58,7 @@ impl Compiler {
         }
     }
 
-    fn compile_kwargs(&mut self, kwargs: HashMap<String, Expression>) {
+    fn compile_kwargs(&mut self, kwargs: BTreeMap<String, Expression>) {
         let num_args = kwargs.len();
         // TODO: push a single instr for all keys as a Vec<String> like Python? bench first
         for (key, value) in kwargs {

--- a/tera/src/parsing/parser.rs
+++ b/tera/src/parsing/parser.rs
@@ -373,8 +373,8 @@ impl<'a> Parser<'a> {
         Ok(expr)
     }
 
-    fn parse_kwargs(&mut self) -> TeraResult<HashMap<String, Expression>> {
-        let mut kwargs = HashMap::new();
+    fn parse_kwargs(&mut self) -> TeraResult<BTreeMap<String, Expression>> {
+        let mut kwargs = BTreeMap::new();
         let mut kwarg_spans: HashMap<&str, Span> = HashMap::new();
         expect_token!(self, Token::LeftParen, "(")?;
 
@@ -511,7 +511,7 @@ impl<'a> Parser<'a> {
 
     fn parse_filter(&mut self, expr: Expression) -> TeraResult<Expression> {
         let (name, mut span) = expect_token!(self, Token::Ident(id) => id, "identifier")?;
-        let mut kwargs = HashMap::new();
+        let mut kwargs = BTreeMap::new();
 
         // We have potentially args to handle
         if matches!(self.next, Some(Ok((Token::LeftParen, _)))) {
@@ -531,7 +531,7 @@ impl<'a> Parser<'a> {
 
     fn parse_test(&mut self, expr: Expression) -> TeraResult<Expression> {
         let (name, mut span) = expect_token!(self, Token::Ident(id) => id, "identifier")?;
-        let mut kwargs = HashMap::new();
+        let mut kwargs = BTreeMap::new();
 
         // We have potentially args to handle
         if matches!(self.next, Some(Ok((Token::LeftParen, _)))) {

--- a/tera/src/parsing/parser.rs
+++ b/tera/src/parsing/parser.rs
@@ -1613,25 +1613,27 @@ impl<'a> Parser<'a> {
                 Ok(Some(Node::If(node)))
             }
             Token::Ident("filter") => {
-                self.body_contexts.push(BodyContext::Capture);
-                let (name, ident_span) = expect_token!(self, Token::Ident(s) => s, "identifier")?;
+                let mut filters = Vec::with_capacity(1);
 
-                let kwargs = if matches!(self.next, Some(Ok((Token::LeftParen, _)))) {
-                    self.parse_kwargs()?
-                } else {
-                    HashMap::new()
-                };
-                let mut fn_span = ident_span.clone();
-                fn_span.expand(&self.current_span);
-                expect_token!(self, Token::TagEnd(..), "%}")?;
+                loop {
+                    filters.push(self.parse_filter(Expression::Const(Spanned::new(
+                        Value::none(),
+                        self.current_span.clone(),
+                    )))?);
+
+                    if let Some(Ok((Token::Pipe, _))) = self.next {
+                        expect_token!(self, Token::Pipe, "|")?;
+                    } else {
+                        expect_token!(self, Token::TagEnd(..), "%}")?;
+                        break;
+                    }
+                }
+
+                self.body_contexts.push(BodyContext::Capture);
                 let body = self.parse_until(|tok| matches!(tok, Token::Ident("endfilter")))?;
                 self.next_or_error()?;
                 self.body_contexts.pop();
-                Ok(Some(Node::FilterSection(FilterSection {
-                    name: Spanned::new(name.to_owned(), ident_span),
-                    kwargs,
-                    body,
-                })))
+                Ok(Some(Node::FilterSection(FilterSection { filters, body })))
             }
             Token::Ident("component") => {
                 let component_def = self.parse_component_definition()?;

--- a/tera/src/snapshot_tests/compiler_inputs/success/filter_section.txt
+++ b/tera/src/snapshot_tests/compiler_inputs/success/filter_section.txt
@@ -1,3 +1,3 @@
-{% filter capitalize(lang="fr") %}
+{% filter capitalize(lang="fr") | safe %}
 Hello {{ world }}
 {% endfilter %}

--- a/tera/src/snapshot_tests/parser_inputs/success/tags/filter_section.txt
+++ b/tera/src/snapshot_tests/parser_inputs/success/tags/filter_section.txt
@@ -1,3 +1,4 @@
 {% filter safe %} hello {% endfilter %}
 {% filter upper(hey=1) -%} hello {%- endfilter %}
 {% filter upper(hey=1) -%}{% if true %}a{%endif %}{%- endfilter %}
+{% filter safe | replace(from="Robert", to="Bob") -%} Hello, I'm Robert {%- endfilter %}

--- a/tera/src/snapshot_tests/rendering_inputs/success/filter_section.txt
+++ b/tera/src/snapshot_tests/rendering_inputs/success/filter_section.txt
@@ -1,0 +1,1 @@
+{% filter replace(from="Robert", to="Bob") | safe -%} Hello I'm Robert! {%- endfilter %}

--- a/tera/src/snapshot_tests/rendering_inputs/success/filter_section.txt
+++ b/tera/src/snapshot_tests/rendering_inputs/success/filter_section.txt
@@ -1,1 +1,1 @@
-{% filter replace(from="Robert", to="Bob") | safe -%} Hello I'm Robert! {%- endfilter %}
+{% filter replace(from="Robert", to="Bob") | upper | safe -%} Hello I'm Robert! {%- endfilter %}

--- a/tera/src/snapshot_tests/snapshots/tera__snapshot_tests__compiler__compiler_ok@filter_section.txt.snap
+++ b/tera/src/snapshot_tests/snapshots/tera__snapshot_tests__compiler__compiler_ok@filter_section.txt.snap
@@ -14,4 +14,6 @@ input_file: tera/src/snapshot_tests/compiler_inputs/success/filter_section.txt
 0007 LoadConst(String("fr"))
 0008 BuildMap(1)
 0009 ApplyFilter("capitalize")
-0010 WriteTop
+0010 BuildMap(0)
+0011 ApplyFilter("safe")
+0012 WriteTop

--- a/tera/src/snapshot_tests/snapshots/tera__snapshot_tests__parser__parser_tags_success@filter_section.txt.snap
+++ b/tera/src/snapshot_tests/snapshots/tera__snapshot_tests__parser__parser_tags_success@filter_section.txt.snap
@@ -5,26 +5,41 @@ input_file: tera/src/snapshot_tests/parser_inputs/success/tags/filter_section.tx
 ---
 [
     FilterSection {
-        name: "safe" @ 1:10-1:14 (10..14),
-        kwargs: {},
+        filters: [
+            Filter {
+                expr: () @ 1:3-1:9 (3..9),
+                name: "safe",
+                kwargs: {},
+            } @ 1:10-1:14 (10..14),
+        ],
         body: [
             " hello ",
         ],
     },
     FilterSection {
-        name: "upper" @ 2:10-2:15 (50..55),
-        kwargs: {
-            "hey": 1 @ 2:20-2:21 (60..61),
-        },
+        filters: [
+            Filter {
+                expr: () @ 2:3-2:9 (43..49),
+                name: "upper",
+                kwargs: {
+                    "hey": 1 @ 2:20-2:21 (60..61),
+                },
+            } @ 2:10-2:22 (50..62),
+        ],
         body: [
             "hello",
         ],
     },
     FilterSection {
-        name: "upper" @ 3:10-3:15 (100..105),
-        kwargs: {
-            "hey": 1 @ 3:20-3:21 (110..111),
-        },
+        filters: [
+            Filter {
+                expr: () @ 3:3-3:9 (93..99),
+                name: "upper",
+                kwargs: {
+                    "hey": 1 @ 3:20-3:21 (110..111),
+                },
+            } @ 3:10-3:22 (100..112),
+        ],
         body: [
             If {
                 expr: true @ 3:32-3:36 (122..126),

--- a/tera/src/snapshot_tests/snapshots/tera__snapshot_tests__parser__parser_tags_success@filter_section.txt.snap
+++ b/tera/src/snapshot_tests/snapshots/tera__snapshot_tests__parser__parser_tags_success@filter_section.txt.snap
@@ -50,4 +50,24 @@ input_file: tera/src/snapshot_tests/parser_inputs/success/tags/filter_section.tx
             },
         ],
     },
+    FilterSection {
+        filters: [
+            Filter {
+                expr: () @ 4:3-4:9 (160..166),
+                name: "safe",
+                kwargs: {},
+            } @ 4:10-4:14 (167..171),
+            Filter {
+                expr: () @ 4:15-4:16 (172..173),
+                name: "replace",
+                kwargs: {
+                    "from": "Robert" @ 4:30-4:38 (187..195),
+                    "to": "Bob" @ 4:43-4:48 (200..205),
+                },
+            } @ 4:17-4:49 (174..206),
+        ],
+        body: [
+            "Hello, I'm Robert",
+        ],
+    },
 ]

--- a/tera/src/snapshot_tests/snapshots/tera__snapshot_tests__parser__parser_templates_success@tpl_slightly_complex.txt.snap
+++ b/tera/src/snapshot_tests/snapshots/tera__snapshot_tests__parser__parser_templates_success@tpl_slightly_complex.txt.snap
@@ -87,8 +87,13 @@ input_file: tera/src/snapshot_tests/parser_inputs/success/tpl/tpl_slightly_compl
                     } @ 9:23-9:84 (265..326),
                     "\n\n            ",
                     FilterSection {
-                        name: "markdown" @ 11:22-11:30 (353..361),
-                        kwargs: {},
+                        filters: [
+                            Filter {
+                                expr: () @ 11:15-11:21 (346..352),
+                                name: "markdown",
+                                kwargs: {},
+                            } @ 11:22-11:30 (353..361),
+                        ],
                         body: [
                             "\n            ## Description\n\n            ",
                             Filter {

--- a/tera/src/snapshot_tests/snapshots/tera__snapshot_tests__rendering__rendering_ok@filter_section.txt.snap
+++ b/tera/src/snapshot_tests/snapshots/tera__snapshot_tests__rendering__rendering_ok@filter_section.txt.snap
@@ -1,0 +1,6 @@
+---
+source: tera/src/snapshot_tests/rendering.rs
+expression: "&normalized_out"
+input_file: tera/src/snapshot_tests/rendering_inputs/success/filter_section.txt
+---
+Hello I'm Bob!

--- a/tera/src/snapshot_tests/snapshots/tera__snapshot_tests__rendering__rendering_ok@filter_section.txt.snap
+++ b/tera/src/snapshot_tests/snapshots/tera__snapshot_tests__rendering__rendering_ok@filter_section.txt.snap
@@ -3,4 +3,4 @@ source: tera/src/snapshot_tests/rendering.rs
 expression: "&normalized_out"
 input_file: tera/src/snapshot_tests/rendering_inputs/success/filter_section.txt
 ---
-Hello I'm Bob!
+HELLO I'M BOB!


### PR DESCRIPTION
Adds support for chaining multiple filters in a single `{% filter %} ... {% endfilter %}` section, with each filter delimited by the `|` character. For instance, the following:

```jinja2
{% filter safe %}{% filter replace(from="Robert", to="Bob") %}{% filter indent %}
Hello, I'm Robert!
{% endfilter %}{% endfilter %}{% endfilter %}
```

may now be rewritten as:

```jinja2
{% filter indent | replace(from="Robert", to="Bob") | safe %}
Hello, I'm Robert!
{% endfilter %}
```

Closes #757.

Looking forward to using this feature while tackling https://github.com/ebkalderon/terminus/issues/27.