### PR TITLE
Explicitly specify the serde/derive dev-dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,6 @@ dependencies = [
  "itoa",
  "pulldown-cmark-escape",
  "serde",
- "serde_derive",
  "tempfile",
  "unicode-segmentation",
  "walkdir",

--- a/tera/Cargo.toml
+++ b/tera/Cargo.toml
@@ -45,7 +45,6 @@ glob_fs = ["dep:walkdir", "dep:globset"]
 criterion = "0.8"
 insta = { version = "1", features = ["glob"] }
 serde = { version = "1", features = ["derive"] }
-serde_derive = "1.0.156"
 tempfile = "3"
 
 [package.metadata.docs.rs]

--- a/tera/Cargo.toml
+++ b/tera/Cargo.toml
@@ -44,6 +44,7 @@ glob_fs = ["dep:walkdir", "dep:globset"]
 [dev-dependencies]
 criterion = "0.8"
 insta = { version = "1", features = ["glob"] }
+serde = { version = "1", features = ["derive"] }
 serde_derive = "1.0.156"
 tempfile = "3"
 

--- a/tera/benches/templates.rs
+++ b/tera/benches/templates.rs
@@ -2,7 +2,7 @@ use std::hint::black_box;
 
 use criterion::{Criterion, criterion_group, criterion_main};
 
-use serde_derive::Serialize;
+use serde::Serialize;
 
 use tera::{Context, Tera};
 

--- a/tera/benches/value.rs
+++ b/tera/benches/value.rs
@@ -2,7 +2,7 @@ use std::hint::black_box;
 use std::path::PathBuf;
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use serde_derive::Serialize;
+use serde::Serialize;
 
 use tera::value::Value;
 

--- a/tera/src/value/de.rs
+++ b/tera/src/value/de.rs
@@ -244,7 +244,7 @@ impl<'de> de::Deserializer<'de> for &Value {
 mod tests {
     use super::*;
     use serde::Deserialize;
-    use serde_derive::Serialize;
+    use serde::Serialize;
 
     #[derive(Debug, Serialize, Deserialize, PartialEq)]
     enum Kind {

--- a/tera/src/value/ser.rs
+++ b/tera/src/value/ser.rs
@@ -632,7 +632,7 @@ mod tests {
 
     #[test]
     fn from_serializable_nested_values_are_cloned() {
-        #[derive(serde_derive::Serialize)]
+        #[derive(serde::Serialize)]
         struct Section {
             name: &'static str,
             children: Vec<Value>,

--- a/tera/tests/undefined.rs
+++ b/tera/tests/undefined.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use serde_derive::Serialize;
+use serde::Serialize;
 
 use tera::{Context, Tera, Value};
 


### PR DESCRIPTION
In downstream packaging for Fedora, we routinely patch out dev-dependencies on `criterion` because they are unnecessary (we run tests, but not benchmarks) and bring in a large tree of otherwise-unnecessary dependencies.

It turns out that dropping the `criterion` dev-dependency by removing this line from `Cargo.toml`

https://github.com/Keats/tera/blob/f345cf2370456a868a5074ad2372ff4db8ecbcc0/tera/Cargo.toml#L45

breaks compiling the tests and examples, with many errors like:

```
error: cannot find derive macro `Serialize` in this scope
 --> examples/teams.rs:5:10
  |
5 | #[derive(Serialize)]
  |          ^^^^^^^^^
  |
note: `Serialize` is imported here, but it is only a trait, without a derive macro
 --> examples/teams.rs:1:5
  |
1 | use serde::Serialize;
  |     ^^^^^^^^^^^^^^^^
help: consider importing this derive macro
  |
1 + use serde_derive::Serialize;
  |
```

This is because tests and examples rely on the `derive` feature of the `serde` crate (not just having `serde_derive` in the dependency tree, although the explicit dependency on it is correct since `serde_derive::Serialize` is used directly), but there’s no (dev-)dependency on `serde` with the `derive` feature. Instead, `criterion` happens to depend on `serde/derive`, so it gets enabled due to [feature unification](https://doc.rust-lang.org/cargo/reference/features.html#feature-unification).

To be more explicit about this requirement, to guard against possible changes in the features used by `criterion` or perhaps a future switch to a different benchmarking library, and to make downstream packaging easier, this PR adds an explicit dev-dependency on `serde/derive`.