### PR TITLE
Only run parsing::instructions::tests::test_size on 64-bit targets

### DIFF
--- a/tera/src/parsing/instructions.rs
+++ b/tera/src/parsing/instructions.rs
@@ -348,6 +348,8 @@ impl fmt::Debug for Chunk {
 mod tests {
     use super::*;
 
+    // Expected size is based on a typical 64-bit target
+    #[cfg(target_pointer_width = "64")]
     #[test]
     fn test_size() {
         assert_eq!(std::mem::size_of::<Instruction>(), 32);


### PR DESCRIPTION
In Fedora, we still build and test Rust library crates on `i686` by default due to the existence of multilib packages for `x86_64`. The addition of `#[cfg(any(target_pointer_width = "64", target_pointer_width = "32"))]` to cover any other possible pointer widths is pedantic, since this crate will probably never be used on any other pointer width.

An alternative, if you only care about checking the size on 64-bit targets, would be to guard the test with

```rust
// Expected size is based on a typical 64-bit target
#[cfg(any(target_pointer_width = "64"))]
```

and move on.