### PR TITLE
Guard Compiler::compile_expr's recursion depth

### DIFF
--- a/tera/src/parsing/ast.rs
+++ b/tera/src/parsing/ast.rs
@@ -166,6 +166,122 @@ impl Expression {
             Expression::ListComprehension(s) => s.span_mut().expand(span),
         }
     }
+
+    /// Drops `self` iteratively instead of relying on the default, recursive `Drop` glue.
+    ///
+    /// `Expression` is a boxed recursive tree (each nested expression sits behind a `Box` in
+    /// its `Spanned<T>` wrapper), so the compiler-generated `Drop` implementation walks it
+    /// recursively -- one stack frame per level. For a sufficiently deep left-leaning chain
+    /// (`1 + 1 + ... + 1`), simply *dropping* the tree can overflow the stack on its own, even
+    /// with nothing else recursing over it.
+    ///
+    /// This matters specifically because `Compiler::compile_expr`'s recursion guard (see
+    /// `parsing/compiler.rs`) can return an error *before* fully consuming a deeply nested
+    /// `Expression` it was handed -- at that point the still-mostly-intact remainder of the
+    /// tree would otherwise be dropped in one shot by the caller. Call this method instead of
+    /// letting that happen implicitly.
+    ///
+    /// This does not need to be (and is not) a general `Drop` impl: every other place an
+    /// `Expression` is consumed already walks it one level at a time via `compile_expr`'s own
+    /// (now depth-guarded) recursion, so the tree is always shallow by the time it would
+    /// naturally go out of scope.
+    pub(crate) fn drop_iteratively(self) {
+        let mut stack = vec![self];
+        while let Some(expr) = stack.pop() {
+            match expr {
+                Expression::BinaryOperation(e) => {
+                    let (op, _) = e.into_parts();
+                    stack.push(op.left);
+                    stack.push(op.right);
+                }
+                Expression::UnaryOperation(e) => {
+                    let (op, _) = e.into_parts();
+                    stack.push(op.expr);
+                }
+                Expression::GetAttr(e) => {
+                    let (attr, _) = e.into_parts();
+                    stack.push(attr.expr);
+                }
+                Expression::GetItem(e) => {
+                    let (item, _) = e.into_parts();
+                    stack.push(item.expr);
+                    stack.push(item.sub_expr);
+                }
+                Expression::Slice(e) => {
+                    let (slice, _) = e.into_parts();
+                    stack.push(slice.expr);
+                    if let Some(e) = slice.start {
+                        stack.push(e);
+                    }
+                    if let Some(e) = slice.end {
+                        stack.push(e);
+                    }
+                    if let Some(e) = slice.step {
+                        stack.push(e);
+                    }
+                }
+                Expression::Filter(e) => {
+                    let (filter, _) = e.into_parts();
+                    stack.push(filter.expr);
+                    stack.extend(filter.kwargs.into_values());
+                }
+                Expression::Test(e) => {
+                    let (test, _) = e.into_parts();
+                    stack.push(test.expr);
+                    stack.extend(test.kwargs.into_values());
+                }
+                Expression::Ternary(e) => {
+                    let (t, _) = e.into_parts();
+                    stack.push(t.expr);
+                    stack.push(t.true_expr);
+                    stack.push(t.false_expr);
+                }
+                Expression::ListComprehension(e) => {
+                    let (lc, _) = e.into_parts();
+                    stack.push(lc.expr);
+                    stack.push(lc.target);
+                    if let Some(e) = lc.condition {
+                        stack.push(e);
+                    }
+                }
+                Expression::ComponentCall(e) => {
+                    let (cc, _) = e.into_parts();
+                    for entry in cc.kwargs {
+                        match entry {
+                            MapEntry::KeyValue { value, .. } => stack.push(value),
+                            MapEntry::Spread(e) => stack.push(e),
+                        }
+                    }
+                    // `cc.body` is `Vec<Node>`, a statement tree the parser already bounds via
+                    // its own `MAX_RECURSION_DEPTH` guard on nesting depth, so it can't reach
+                    // the size needed to overflow on drop the way an expression chain can.
+                }
+                Expression::FunctionCall(e) => {
+                    let (fc, _) = e.into_parts();
+                    stack.extend(fc.kwargs.into_values());
+                }
+                Expression::Array(e) => {
+                    let (array, _) = e.into_parts();
+                    for entry in array.items {
+                        match entry {
+                            ArrayEntry::Item(e) | ArrayEntry::Spread(e) => stack.push(e),
+                        }
+                    }
+                }
+                Expression::Map(e) => {
+                    let (map, _) = e.into_parts();
+                    for entry in map.entries {
+                        match entry {
+                            MapEntry::KeyValue { value, .. } => stack.push(value),
+                            MapEntry::Spread(e) => stack.push(e),
+                        }
+                    }
+                }
+                // Leaf variants: nothing to recurse into, drop normally.
+                Expression::Const(_) | Expression::Var(_) => {}
+            }
+        }
+    }
 }
 
 impl fmt::Debug for Expression {

--- a/tera/src/parsing/compiler.rs
+++ b/tera/src/parsing/compiler.rs
@@ -3,10 +3,12 @@
 use std::collections::{BTreeMap, HashSet};
 
 use crate::HashMap;
+use crate::errors::{Error, TeraResult};
 use crate::parsing::ast::{
     ArrayEntry, BinaryOperator, Block, Expression, MapEntry, Node, UnaryOperator,
 };
 use crate::parsing::instructions::{Chunk, Instruction};
+use crate::parsing::parser::MAX_RECURSION_DEPTH;
 use crate::utils::Span;
 use crate::value::Value;
 
@@ -38,6 +40,9 @@ pub(crate) struct Compiler {
     pub(crate) top_level_variables: HashSet<String>,
     /// Represents variables set by a loop or by set
     pub(crate) temp_variables: Vec<HashSet<String>>,
+    /// Recursion depth while compiling expressions, guarded the same way the parser guards
+    /// its own recursion -- see `compile_expr`.
+    recursion_depth: usize,
 }
 
 impl Compiler {
@@ -55,10 +60,11 @@ impl Compiler {
             top_level_variables: HashSet::default(),
             temp_variables: vec![HashSet::new()],
             block_depth: 0,
+            recursion_depth: 0,
         }
     }
 
-    fn compile_kwargs(&mut self, kwargs: BTreeMap<String, Expression>) {
+    fn compile_kwargs(&mut self, kwargs: BTreeMap<String, Expression>) -> TeraResult<()> {
         let num_args = kwargs.len();
         // TODO: push a single instr for all keys as a Vec<String> like Python? bench first
         for (key, value) in kwargs {
@@ -66,12 +72,17 @@ impl Compiler {
                 Instruction::LoadConst(Value::from(key)),
                 Some(value.span().clone()),
             );
-            self.compile_expr(value);
+            self.compile_expr(value)?;
         }
         self.chunk.add(Instruction::BuildMap(num_args), None);
+        Ok(())
     }
 
-    fn compile_map_entries(&mut self, entries: Vec<MapEntry>, span: Option<Span>) {
+    fn compile_map_entries(
+        &mut self,
+        entries: Vec<MapEntry>,
+        span: Option<Span>,
+    ) -> TeraResult<()> {
         let has_spreads = entries.iter().any(|e| matches!(e, MapEntry::Spread(_)));
 
         if has_spreads {
@@ -83,11 +94,11 @@ impl Compiler {
                             Instruction::LoadConst(Value::from(key)),
                             Some(value.span().clone()),
                         );
-                        self.compile_expr(value);
+                        self.compile_expr(value)?;
                         entry_types.push(false);
                     }
                     MapEntry::Spread(expr) => {
-                        self.compile_expr(expr);
+                        self.compile_expr(expr)?;
                         entry_types.push(true);
                     }
                 }
@@ -102,14 +113,41 @@ impl Compiler {
                         Instruction::LoadConst(Value::from(key)),
                         Some(value.span().clone()),
                     );
-                    self.compile_expr(value);
+                    self.compile_expr(value)?;
                 }
             }
             self.chunk.add(Instruction::BuildMap(num_items), span);
         }
+        Ok(())
     }
 
-    fn compile_expr(&mut self, expr: Expression) {
+    /// This is called recursively (both directly and via `compile_node`/`compile_kwargs`/
+    /// `compile_map_entries`) so we put a limit on how deep it can go, mirroring the parser's
+    /// own `MAX_RECURSION_DEPTH` guard. The parser only guards *its own* recursive descent
+    /// (parenthesized/unary expressions); left-associative chains like `1 + 1 + ...` are built
+    /// *iteratively* by the parser and never trip that guard, but the compiler still walks the
+    /// resulting AST recursively, so it needs its own bound.
+    fn compile_expr(&mut self, expr: Expression) -> TeraResult<()> {
+        self.recursion_depth += 1;
+        if self.recursion_depth > MAX_RECURSION_DEPTH {
+            self.recursion_depth -= 1;
+            let span = expr.span().clone();
+            // `expr` can still be a very deep, mostly-untouched tree at this point (we're
+            // bailing out before compiling any of it). Letting it drop normally here would
+            // trade the recursive-*compile* stack overflow this guard exists to prevent for a
+            // recursive-*drop* one instead, so unwind it iteratively.
+            expr.drop_iteratively();
+            return Err(Error::syntax_error(
+                "The expression is too complex".to_string(),
+                &span,
+            ));
+        }
+        let res = self.compile_expr_inner(expr);
+        self.recursion_depth -= 1;
+        res
+    }
+
+    fn compile_expr_inner(&mut self, expr: Expression) -> TeraResult<()> {
         match expr {
             Expression::Const(e) => {
                 let (val, span) = e.into_parts();
@@ -117,7 +155,7 @@ impl Compiler {
             }
             Expression::Map(e) => {
                 let (map, span) = e.into_parts();
-                self.compile_map_entries(map.entries, Some(span));
+                self.compile_map_entries(map.entries, Some(span))?;
             }
             Expression::Array(e) => {
                 let (array, span) = e.into_parts();
@@ -132,11 +170,11 @@ impl Compiler {
                     for entry in array.items {
                         match entry {
                             ArrayEntry::Item(expr) => {
-                                self.compile_expr(expr);
+                                self.compile_expr(expr)?;
                                 entry_types.push(false);
                             }
                             ArrayEntry::Spread(expr) => {
-                                self.compile_expr(expr);
+                                self.compile_expr(expr)?;
                                 entry_types.push(true);
                             }
                         }
@@ -148,7 +186,7 @@ impl Compiler {
                     let num_elems = array.items.len();
                     for entry in array.items {
                         if let ArrayEntry::Item(expr) = entry {
-                            self.compile_expr(expr);
+                            self.compile_expr(expr)?;
                         }
                     }
                     self.chunk
@@ -174,7 +212,7 @@ impl Compiler {
             }
             Expression::GetAttr(e) => {
                 let (attr, span) = e.into_parts();
-                self.compile_expr(attr.expr);
+                self.compile_expr(attr.expr)?;
                 if attr.optional {
                     self.chunk
                         .add(Instruction::LoadAttrOpt(attr.name), Some(span));
@@ -184,8 +222,8 @@ impl Compiler {
             }
             Expression::GetItem(e) => {
                 let (item, span) = e.into_parts();
-                self.compile_expr(item.expr);
-                self.compile_expr(item.sub_expr);
+                self.compile_expr(item.expr)?;
+                self.compile_expr(item.sub_expr)?;
                 if item.optional {
                     self.chunk.add(Instruction::BinarySubscriptOpt, Some(span));
                 } else {
@@ -194,21 +232,21 @@ impl Compiler {
             }
             Expression::Slice(e) => {
                 let (slice, span) = e.into_parts();
-                self.compile_expr(slice.expr);
+                self.compile_expr(slice.expr)?;
                 if let Some(start) = slice.start {
-                    self.compile_expr(start);
+                    self.compile_expr(start)?;
                 } else {
                     self.chunk.add(Instruction::LoadConst(Value::none()), None);
                 }
 
                 if let Some(end) = slice.end {
-                    self.compile_expr(end);
+                    self.compile_expr(end)?;
                 } else {
                     self.chunk.add(Instruction::LoadConst(Value::none()), None);
                 }
 
                 if let Some(step) = slice.step {
-                    self.compile_expr(step);
+                    self.compile_expr(step)?;
                 } else {
                     self.chunk.add(Instruction::LoadConst(1.into()), None);
                 }
@@ -221,8 +259,8 @@ impl Compiler {
             }
             Expression::Filter(e) => {
                 let (filter, span) = e.into_parts();
-                self.compile_expr(filter.expr);
-                self.compile_kwargs(filter.kwargs);
+                self.compile_expr(filter.expr)?;
+                self.compile_kwargs(filter.kwargs)?;
                 self.filter_calls
                     .entry(filter.name.clone())
                     .or_default()
@@ -232,8 +270,8 @@ impl Compiler {
             }
             Expression::Test(e) => {
                 let (test, span) = e.into_parts();
-                self.compile_expr(test.expr);
-                self.compile_kwargs(test.kwargs);
+                self.compile_expr(test.expr)?;
+                self.compile_kwargs(test.kwargs)?;
                 self.test_calls
                     .entry(test.name.clone())
                     .or_default()
@@ -242,14 +280,14 @@ impl Compiler {
             }
             Expression::Ternary(e) => {
                 let (ternary, _) = e.into_parts();
-                self.compile_expr(ternary.expr);
+                self.compile_expr(ternary.expr)?;
                 let idx = self.chunk.add(Instruction::PopJumpIfFalse(0), None) as usize;
                 self.processing_bodies.push(ProcessingBody::Branch(idx));
-                self.compile_expr(ternary.true_expr);
+                self.compile_expr(ternary.true_expr)?;
                 let idx = self.chunk.add(Instruction::Jump(0), None) as usize;
                 self.end_branch(self.chunk.len());
                 self.processing_bodies.push(ProcessingBody::Branch(idx));
-                self.compile_expr(ternary.false_expr);
+                self.compile_expr(ternary.false_expr)?;
                 self.end_branch(self.chunk.len());
             }
             Expression::ListComprehension(e) => {
@@ -257,7 +295,7 @@ impl Compiler {
 
                 self.chunk
                     .add(Instruction::BuildList(0), Some(span.clone()));
-                self.compile_expr(list_comp.target);
+                self.compile_expr(list_comp.target)?;
                 self.chunk.add(
                     Instruction::StartIterateComprehension(list_comp.key.is_some()),
                     None,
@@ -274,12 +312,12 @@ impl Compiler {
 
                 let start_idx = self.chunk.add(Instruction::Iterate(0), None) as usize;
                 let cond_skip_idx = if let Some(c) = list_comp.condition {
-                    self.compile_expr(c);
+                    self.compile_expr(c)?;
                     Some(self.chunk.add(Instruction::PopJumpIfFalse(0), None) as usize)
                 } else {
                     None
                 };
-                self.compile_expr(list_comp.expr);
+                self.compile_expr(list_comp.expr)?;
                 self.chunk.add(Instruction::AppendToList, None);
                 if let Some(idx) = cond_skip_idx {
                     let jump_back_target = self.chunk.len();
@@ -312,12 +350,12 @@ impl Compiler {
                 if !component_call.self_closing {
                     self.chunk.add(Instruction::Capture, None);
                     for node in component_call.body {
-                        self.compile_node(node);
+                        self.compile_node(node)?;
                     }
                     self.chunk.add(Instruction::EndCapture, Some(span.clone()));
                 }
 
-                self.compile_map_entries(component_call.kwargs, None);
+                self.compile_map_entries(component_call.kwargs, None)?;
 
                 if component_call.self_closing {
                     self.chunk.add(
@@ -333,7 +371,7 @@ impl Compiler {
             }
             Expression::FunctionCall(e) => {
                 let (func, span) = e.into_parts();
-                self.compile_kwargs(func.kwargs);
+                self.compile_kwargs(func.kwargs)?;
                 self.function_calls
                     .entry(func.name.clone())
                     .or_default()
@@ -343,7 +381,7 @@ impl Compiler {
             }
             Expression::UnaryOperation(e) => {
                 let (op, span) = e.into_parts();
-                self.compile_expr(op.expr);
+                self.compile_expr(op.expr)?;
                 match op.op {
                     UnaryOperator::Not => self.chunk.add(Instruction::Not, Some(span)),
                     UnaryOperator::Minus => self.chunk.add(Instruction::Negative, Some(span)),
@@ -370,7 +408,7 @@ impl Compiler {
                     BinaryOperator::And | BinaryOperator::Or => {
                         self.processing_bodies
                             .push(ProcessingBody::ShortCircuit(vec![]));
-                        self.compile_expr(op.left);
+                        self.compile_expr(op.left)?;
                         if let Some(ProcessingBody::ShortCircuit(instr)) =
                             self.processing_bodies.last_mut()
                         {
@@ -385,7 +423,7 @@ impl Compiler {
                         } else {
                             unreachable!();
                         }
-                        self.compile_expr(op.right);
+                        self.compile_expr(op.right)?;
                         let end = self.chunk.len();
                         if let Some(ProcessingBody::ShortCircuit(instr)) =
                             self.processing_bodies.pop()
@@ -402,7 +440,7 @@ impl Compiler {
                         } else {
                             unreachable!()
                         }
-                        return;
+                        return Ok(());
                     }
                     // These are not really binops and we already switched them to separate AST
                     // nodes in the parser so we are not going to have them here
@@ -411,14 +449,15 @@ impl Compiler {
                 // TODO: implement constant folding for arithmetics, string concat
                 // Value::constant_fold(self, other) -> Option<Value>?
                 // need to pass the op as well...^
-                self.compile_expr(op.left);
-                self.compile_expr(op.right);
+                self.compile_expr(op.left)?;
+                self.compile_expr(op.right)?;
                 self.chunk.add(instr, Some(span));
             }
         }
+        Ok(())
     }
 
-    fn compile_block(&mut self, block: Block) {
+    fn compile_block(&mut self, block: Block) -> TeraResult<()> {
         let (block_name, block_span) = block.name.into_parts();
         let is_top_level = self.block_depth == 0;
 
@@ -427,7 +466,7 @@ impl Compiler {
         let parent_bodies = std::mem::take(&mut self.processing_bodies);
         self.block_depth += 1;
         for node in block.body {
-            self.compile_node(node);
+            self.compile_node(node)?;
         }
         self.block_depth -= 1;
         let block_chunk = std::mem::replace(&mut self.chunk, parent_chunk);
@@ -438,6 +477,7 @@ impl Compiler {
         }
         self.blocks.insert(block_name.clone(), block_chunk);
         self.chunk.add(Instruction::RenderBlock(block_name), None);
+        Ok(())
     }
 
     fn end_branch(&mut self, idx: usize) {
@@ -460,17 +500,17 @@ impl Compiler {
             .find(|b| matches!(b, ProcessingBody::Loop(..)))
     }
 
-    pub fn compile_node(&mut self, node: Node) {
+    pub fn compile_node(&mut self, node: Node) -> TeraResult<()> {
         match node {
             Node::Content(text) => {
                 self.chunk.add(Instruction::WriteText(text), None);
             }
             Node::Expression(expr) => {
-                self.compile_expr(expr);
+                self.compile_expr(expr)?;
                 self.chunk.add(Instruction::WriteTop, None);
             }
             Node::Set(s) => {
-                self.compile_expr(s.value);
+                self.compile_expr(s.value)?;
                 let scope = if s.global {
                     self.temp_variables.first_mut()
                 } else {
@@ -487,7 +527,7 @@ impl Compiler {
             Node::BlockSet(b) => {
                 self.chunk.add(Instruction::Capture, None);
                 for node in b.body {
-                    self.compile_node(node);
+                    self.compile_node(node)?;
                 }
                 // We can only have an error on a filter so point to the first one
                 let capture_span = b.filters.first().map(|f| f.span().clone());
@@ -495,7 +535,7 @@ impl Compiler {
                 for expr in b.filters {
                     if let Expression::Filter(f) = expr {
                         let (filter, span) = f.into_parts();
-                        self.compile_kwargs(filter.kwargs);
+                        self.compile_kwargs(filter.kwargs)?;
                         self.filter_calls
                             .entry(filter.name.clone())
                             .or_default()
@@ -526,10 +566,10 @@ impl Compiler {
                 self.chunk.add(Instruction::Include(name), Some(span));
             }
             Node::Block(b) => {
-                self.compile_block(b);
+                self.compile_block(b)?;
             }
             Node::ForLoop(forloop) => {
-                self.compile_expr(forloop.target);
+                self.compile_expr(forloop.target)?;
                 self.chunk
                     .add(Instruction::StartIterate(forloop.key.is_some()), None);
                 // The value is sent before the key to be consistent with a value only loop
@@ -546,7 +586,7 @@ impl Compiler {
                 self.processing_bodies.push(ProcessingBody::Loop(start_idx));
 
                 for node in forloop.body {
-                    self.compile_node(node);
+                    self.compile_node(node)?;
                 }
 
                 let has_else = !forloop.else_body.is_empty();
@@ -579,7 +619,7 @@ impl Compiler {
                     let idx = self.chunk.add(Instruction::PopJumpIfFalse(0), None) as usize;
                     self.processing_bodies.push(ProcessingBody::Branch(idx));
                     for node in forloop.else_body {
-                        self.compile_node(node);
+                        self.compile_node(node)?;
                     }
                     self.end_branch(self.chunk.len());
                 }
@@ -593,13 +633,13 @@ impl Compiler {
                 }
             }
             Node::If(i) => {
-                self.compile_expr(i.expr);
+                self.compile_expr(i.expr)?;
 
                 let idx = self.chunk.add(Instruction::PopJumpIfFalse(0), None) as usize;
                 self.processing_bodies.push(ProcessingBody::Branch(idx));
 
                 for node in i.body {
-                    self.compile_node(node);
+                    self.compile_node(node)?;
                 }
 
                 if !i.false_body.is_empty() {
@@ -608,7 +648,7 @@ impl Compiler {
                     self.processing_bodies.push(ProcessingBody::Branch(idx));
 
                     for node in i.false_body {
-                        self.compile_node(node);
+                        self.compile_node(node)?;
                     }
                 }
 
@@ -617,7 +657,7 @@ impl Compiler {
             Node::FilterSection(f) => {
                 self.chunk.add(Instruction::Capture, None);
                 for node in f.body {
-                    self.compile_node(node);
+                    self.compile_node(node)?;
                 }
                 // We can only have an error on a filter so point to the first one
                 let capture_span = f.filters.first().map(|f| f.span().clone());
@@ -625,7 +665,7 @@ impl Compiler {
                 for expr in f.filters {
                     if let Expression::Filter(f) = expr {
                         let (filter, span) = f.into_parts();
-                        self.compile_kwargs(filter.kwargs);
+                        self.compile_kwargs(filter.kwargs)?;
                         self.filter_calls
                             .entry(filter.name.clone())
                             .or_default()
@@ -637,11 +677,13 @@ impl Compiler {
                 self.chunk.add(Instruction::WriteTop, None);
             }
         }
+        Ok(())
     }
 
-    pub fn compile(&mut self, nodes: Vec<Node>) {
+    pub fn compile(&mut self, nodes: Vec<Node>) -> TeraResult<()> {
         for node in nodes {
-            self.compile_node(node);
+            self.compile_node(node)?;
         }
+        Ok(())
     }
 }

--- a/tera/src/parsing/parser.rs
+++ b/tera/src/parsing/parser.rs
@@ -18,7 +18,7 @@ use crate::value::{Key, Value, ValueInner};
 use crate::{HashMap, HashSet};
 
 /// Maximum recursion depth for the parser, shared between expression and statement parsing
-const MAX_RECURSION_DEPTH: usize = 40;
+pub(crate) const MAX_RECURSION_DEPTH: usize = 40;
 /// We only allow that many dimensions in an array literal
 const MAX_DIMENSION_ARRAY: usize = 2;
 /// How many nesting of brackets can we have in an variable, eg `a[b[e]]` counts as 2

--- a/tera/src/snapshot_tests/compiler.rs
+++ b/tera/src/snapshot_tests/compiler.rs
@@ -13,7 +13,7 @@ fn compiler_ok() {
             .unwrap()
             .nodes;
         let mut compiler = Compiler::new(&path.file_name().unwrap().to_string_lossy());
-        compiler.compile(nodes);
+        compiler.compile(nodes).unwrap();
         compiler.chunk.optimize();
 
         insta::assert_debug_snapshot!(compiler.chunk);
@@ -30,7 +30,7 @@ fn compiler_blocks() {
             .unwrap()
             .nodes;
         let mut compiler = Compiler::new(&path.file_name().unwrap().to_string_lossy());
-        compiler.compile(nodes);
+        compiler.compile(nodes).unwrap();
         compiler.chunk.optimize();
 
         let mut s = String::with_capacity(1000);

--- a/tera/src/template.rs
+++ b/tera/src/template.rs
@@ -64,7 +64,7 @@ impl Template {
         let extends = parser_output.parent;
 
         let mut body_compiler = Compiler::new(tpl_name);
-        body_compiler.compile(parser_output.nodes);
+        body_compiler.compile(parser_output.nodes)?;
 
         // Optimize the main chunk
         let mut chunk = body_compiler.chunk;
@@ -93,7 +93,7 @@ impl Template {
             .map(|c| {
                 let mut compiler = Compiler::new(tpl_name);
                 // We don't need the nodes again after it's compiled
-                compiler.compile(c.body.clone());
+                compiler.compile(c.body.clone())?;
                 // Collect filter/test/function/include/component calls from component body
                 for (name, spans) in compiler.filter_calls {
                     filter_calls.entry(name).or_default().extend(spans);
@@ -112,9 +112,9 @@ impl Template {
                 }
                 let mut chunk = compiler.chunk;
                 chunk.optimize();
-                (c.name.clone(), (c, chunk))
+                Ok((c.name.clone(), (c, chunk)))
             })
-            .collect();
+            .collect::<TeraResult<_>>()?;
         let block_name_spans = body_compiler.block_name_spans;
 
         Ok(Self {


### PR DESCRIPTION
Fixes #1035. The parser already bounds its own recursion via MAX_RECURSION_DEPTH, but that guard only fires for right-nested forms built through inner_parse_expression (parentheses, unary operators, **). Left-associative chains -- `1 + 1 + ...`, `a | f | f | ...`, `a.b.c...` -- are built iteratively by the Pratt loop and never increment recursion_depth, so they sail past the parser untouched. Compiler::compile_expr then walks that same left-leaning AST recursively with no guard of its own, so a template with a few thousand chained terms aborts the process with a stack overflow instead of returning an error.

This adds the same MAX_RECURSION_DEPTH guard to compile_expr (now Compiler::compile_expr, wrapping the renamed compile_expr_inner), returning the same "The expression is too complex" error the parser already uses for right-nested forms. Making compile_expr fallible means propagating TeraResult through everything that calls it, directly or transitively: compile_kwargs, compile_map_entries, compile_block, compile_node, and Compiler::compile, plus their two call sites in Template::new.

Second bug found and fixed while verifying this: once the depth guard returns early, the still-mostly-intact remainder of the expression tree it was handed needs to be dropped -- and Expression's default, compiler-derived Drop is itself recursive over that same boxed tree, so a sufficiently large chain (tested: ~55,000+ terms) traded a stack overflow during *compilation* for one during *drop*, on the very error path meant to prevent the crash. Expression::drop_iteratively walks the tree with an explicit heap-allocated stack instead of the call stack, and compile_expr's guard now calls it explicitly on the rejected expression instead of letting it drop implicitly. Verified directly: templates up to 5,000,000 chained terms (about 20MB of source) now return a clean error with no crash, versus overflowing before this second fix at around 55-60k terms.

Tested: `cargo test` and `cargo test --all-features` both pass (139 tests across all_features), `cargo fmt --all --check` and `cargo clippy --all-targets --all-features -- -D warnings` both clean. Verified against the exact reproduction from #1035 plus a range of chain lengths from 100 to 5,000,000 terms to find and confirm both the original threshold and the drop-related one.