### PR TITLE
Strip the int filter base prefix after the sign

### DIFF
--- a/tera/src/filters.rs
+++ b/tera/src/filters.rs
@@ -353,13 +353,23 @@ pub(crate) fn int(val: Value, kwargs: Kwargs, _: &State) -> TeraResult<Value> {
     match val.kind() {
         ValueKind::String => {
             let s = val.as_str().unwrap().trim();
-            let s = match base {
-                2 => s.trim_start_matches("0b"),
-                8 => s.trim_start_matches("0o"),
-                16 => s.trim_start_matches("0x"),
-                _ => s,
+            // The sign comes before the base prefix so it has to be split off first
+            let (sign, digits) = match s.as_bytes().first() {
+                Some(b'-' | b'+') => s.split_at(1),
+                _ => ("", s),
             };
-            match i128::from_str_radix(s, base) {
+            let digits = match base {
+                2 => digits.trim_start_matches("0b"),
+                8 => digits.trim_start_matches("0o"),
+                16 => digits.trim_start_matches("0x"),
+                _ => digits,
+            };
+            let s = if sign.is_empty() {
+                Cow::Borrowed(digits)
+            } else {
+                Cow::Owned(format!("{sign}{digits}"))
+            };
+            match i128::from_str_radix(&s, base) {
                 Ok(v) => Ok(v.into()),
                 Err(_) => {
                     if s.contains('.') {
@@ -799,6 +809,27 @@ mod tests {
         // Doesn't make sense
         assert!(int("hello".into(), Kwargs::default(), &state).is_err());
         assert!(int(vec![1, 2].into(), Kwargs::default(), &state).is_err());
+    }
+
+    #[test]
+    fn test_int_signed_base_prefix() {
+        let ctx = Context::new();
+        let state = State::new(&ctx);
+        let tests: Vec<(&str, u32, i64)> = vec![
+            ("-0b1010", 2, -10),
+            ("+0b1010", 2, 10),
+            ("-0o17", 8, -15),
+            ("+0o17", 8, 15),
+            ("-0xff", 16, -255),
+            ("+0xff", 16, 255),
+        ];
+        for (input, base, expected) in tests {
+            assert_eq!(
+                int(input.into(), Kwargs::from([("base", base.into())]), &state).unwrap(),
+                expected.into(),
+                "input: {input}, base: {base}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
The `int` filter already parses `'-5'` and already parses `'0xff'`. Only their
combination fails: `{{ '-0xff' | int(base=16) }}` aborts the render.

```
'-0xff' | int(base=16)  =>  Err(RenderingError { message: "The string `-0xff` cannot be converted to an int in base 16", span: @ 1:13-1:25 })
'0xff'  | int(base=16)  =>  Ok("255")
'-5'    | int           =>  Ok("-5")
```

`docs/content/_index.md:983-984` says "The `base` argument can be used to
specify how to interpret the number. Bases of 2, 8, and 16 understand the
prefix 0b, 0o, 0x, respectively", with no exclusion for signed input, and the
existing test at `tera/src/filters.rs` covers `'-5'` (signed, unprefixed) and
`'0b1010'` (unsigned, prefixed) but never the signed-and-prefixed cell.

## Cause

`tera/src/filters.rs:354-360` strips the prefix with `trim_start_matches`,
which only matches at position 0:

```rust
let s = match base {
    2 => s.trim_start_matches("0b"),
    ...
};
match i128::from_str_radix(s, base) {
```

`-0xff` starts with `-`, so nothing is stripped and `from_str_radix` rejects
the embedded `x`. The sign comes before the prefix, so it has to be split off
first. `int('-0xff', 16)` is `-255` in Python and `i128::from_str_radix` itself
accepts a leading sign, so re-attaching is enough.

## Change

Split a leading `-`/`+` off, strip the prefix from the remainder, then hand the
sign back to `from_str_radix`. Unsigned input takes a `Cow::Borrowed` and does
not allocate, so the existing path is unchanged. A new `test_int_signed_base_prefix`
covers `{-, +} x {0b, 0o, 0x}`.

## Verification

* Reverting the fix and keeping the test: `test_int_signed_base_prefix` fails
  with `Err value: Msg("The string \`-0b1010\` cannot be converted to an int in
  base 2")`, and the pre-existing `test_int` still passes.
* Over-correcting in the other direction (split the sign, never re-attach it)
  fails `test_int_signed_base_prefix` with `left: I128(10)` for `-0b1010`, and
  also fails your own pre-existing `test_int` at the `'-5'` assertion with
  `left: I128(5)`. So the two mutation directions are separated by `test_int`
  itself, not only by the test I added -- but they are not disjoint: the new
  test fails under both.
* `cargo fmt --all --check`, `cargo clippy --all-targets --all-features --
  -D warnings`, `cargo test`, `cargo test --all-features` all pass. 181 tests
  with `--all-features`, up from 180.

Happy to add a `CHANGELOG.md` entry, though recent merged PRs suggest the
changelog is filled in at release time.

---

Disclosure: this patch was prepared with AI assistance. I ran every check
quoted above myself and I will handle review feedback personally.
